### PR TITLE
Handle Oracle LOB columns when copying data

### DIFF
--- a/src/test/java/com/example/h2sync/service/OracleLoaderServiceTest.java
+++ b/src/test/java/com/example/h2sync/service/OracleLoaderServiceTest.java
@@ -5,6 +5,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 import javax.sql.DataSource;
+import javax.sql.rowset.serial.SerialBlob;
+import javax.sql.rowset.serial.SerialClob;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -12,6 +14,8 @@ import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
@@ -22,8 +26,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class OracleLoaderServiceTest {
 
@@ -81,6 +89,73 @@ class OracleLoaderServiceTest {
 
         String integerType = (String) method.invoke(loader, Types.NUMERIC, 5, 0);
         assertEquals("INTEGER", integerType);
+    }
+
+    @Test
+    void readColumnValueConvertsLobsToSupportedTypes() throws Exception {
+        OracleLoaderService loader = new OracleLoaderService(
+                new JdbcTemplate(newH2DataSource("target" + randomSuffix())),
+                newH2DataSource("oracle" + randomSuffix()),
+                "TEST",
+                1,
+                100,
+                1,
+                ""
+        );
+
+        Method method = OracleLoaderService.class.getDeclaredMethod(
+                "readColumnValue", ResultSet.class, ResultSetMetaData.class, int.class);
+        method.setAccessible(true);
+
+        byte[] blobData = new byte[]{0x01, 0x02, 0x03};
+
+        ResultSet blobRs = mock(ResultSet.class);
+        ResultSetMetaData blobMeta = mock(ResultSetMetaData.class);
+        when(blobMeta.getColumnType(1)).thenReturn(Types.BLOB);
+        when(blobRs.getBytes(1)).thenReturn(blobData);
+        when(blobRs.wasNull()).thenReturn(false);
+        Object blobValue = method.invoke(loader, blobRs, blobMeta, 1);
+        assertArrayEquals(blobData, (byte[]) blobValue);
+
+        ResultSet nullBlobRs = mock(ResultSet.class);
+        ResultSetMetaData nullBlobMeta = mock(ResultSetMetaData.class);
+        when(nullBlobMeta.getColumnType(1)).thenReturn(Types.BLOB);
+        when(nullBlobRs.getBytes(1)).thenReturn(null);
+        when(nullBlobRs.wasNull()).thenReturn(true);
+        Object nullBlobValue = method.invoke(loader, nullBlobRs, nullBlobMeta, 1);
+        assertNull(nullBlobValue);
+
+        ResultSet blobObjectRs = mock(ResultSet.class);
+        ResultSetMetaData blobObjectMeta = mock(ResultSetMetaData.class);
+        when(blobObjectMeta.getColumnType(1)).thenReturn(Types.OTHER);
+        SerialBlob serialBlob = new SerialBlob(blobData);
+        when(blobObjectRs.getObject(1)).thenReturn(serialBlob);
+        Object blobObjectValue = method.invoke(loader, blobObjectRs, blobObjectMeta, 1);
+        assertArrayEquals(blobData, (byte[]) blobObjectValue);
+
+        ResultSet clobRs = mock(ResultSet.class);
+        ResultSetMetaData clobMeta = mock(ResultSetMetaData.class);
+        when(clobMeta.getColumnType(1)).thenReturn(Types.CLOB);
+        when(clobRs.getString(1)).thenReturn("hello");
+        when(clobRs.wasNull()).thenReturn(false);
+        Object clobValue = method.invoke(loader, clobRs, clobMeta, 1);
+        assertEquals("hello", clobValue);
+
+        ResultSet nullClobRs = mock(ResultSet.class);
+        ResultSetMetaData nullClobMeta = mock(ResultSetMetaData.class);
+        when(nullClobMeta.getColumnType(1)).thenReturn(Types.CLOB);
+        when(nullClobRs.getString(1)).thenReturn(null);
+        when(nullClobRs.wasNull()).thenReturn(true);
+        Object nullClobValue = method.invoke(loader, nullClobRs, nullClobMeta, 1);
+        assertNull(nullClobValue);
+
+        ResultSet clobObjectRs = mock(ResultSet.class);
+        ResultSetMetaData clobObjectMeta = mock(ResultSetMetaData.class);
+        when(clobObjectMeta.getColumnType(1)).thenReturn(Types.OTHER);
+        SerialClob serialClob = new SerialClob("world".toCharArray());
+        when(clobObjectRs.getObject(1)).thenReturn(serialClob);
+        Object clobObjectValue = method.invoke(loader, clobObjectRs, clobObjectMeta, 1);
+        assertEquals("world", clobObjectValue);
     }
 
     private static DriverManagerDataSource newH2DataSource(String dbName) {


### PR DESCRIPTION
## Summary
- convert Oracle binary and character LOB columns to supported types before inserting into H2
- add helper utilities to read and release LOB values while respecting metadata types
- extend OracleLoaderServiceTest to cover BLOB and CLOB conversions

## Testing
- mvn -q test *(fails: unable to reach Maven Central in sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfced8c8ac83298780a7082e1e5521