### PR TITLE
Use ROWNUM limit for Oracle sample loader

### DIFF
--- a/src/main/java/com/example/h2sync/service/OracleSampleLoaderService.java
+++ b/src/main/java/com/example/h2sync/service/OracleSampleLoaderService.java
@@ -67,7 +67,10 @@ public class OracleSampleLoaderService extends AbstractOracleLoaderService {
 
     @Override
     protected String buildTableSelectSql(String oracleQualifiedTable, String table) {
-        return "SELECT * FROM " + oracleQualifiedTable + " FETCH FIRST " + rowLimit + " ROWS ONLY";
+        if (rowLimit > 0) {
+            return "SELECT * FROM " + oracleQualifiedTable + " WHERE ROWNUM <= " + rowLimit;
+        }
+        return super.buildTableSelectSql(oracleQualifiedTable, table);
     }
 
     public void runSampleLoad() {


### PR DESCRIPTION
## Summary
- replace the Oracle sample loader query limit with a ROWNUM filter so it works on older Oracle versions
- fall back to the default select when no row limit is configured

## Testing
- mvn -q -DskipTests package *(fails: unable to resolve artifacts because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5153138a08329affa9e3764d76f7b