### PR TITLE
Fix H2 sequence lookup SQL in migration report

### DIFF
--- a/src/main/java/com/example/h2sync/service/MigrationReportPrinter.java
+++ b/src/main/java/com/example/h2sync/service/MigrationReportPrinter.java
@@ -163,8 +163,8 @@ class MigrationReportPrinter {
     }
 
     private NumericResult fetchH2SequenceValue(String sequence) {
-        String sql = "SELECT COALESCE(CURRENT_VALUE, START_VALUE) FROM INFORMATION_SCHEMA.SEQUENCES " +
-                "WHERE UPPER(SEQUENCE_NAME) = ? AND SEQUENCE_SCHEMA = SCHEMA()";
+        String sql = "SELECT COALESCE(\"CURRENT_VALUE\", \"START_VALUE\") FROM INFORMATION_SCHEMA.SEQUENCES " +
+                "WHERE UPPER(SEQUENCE_NAME) = ? AND UPPER(SEQUENCE_SCHEMA) = UPPER(SCHEMA())";
         try {
             BigDecimal value = h2.queryForObject(sql, BigDecimal.class, sequence.toUpperCase(Locale.ROOT));
             if (value == null) {


### PR DESCRIPTION
## Summary
- escape H2 sequence column names when querying INFORMATION_SCHEMA
- compare the H2 sequence schema in a case-insensitive way to avoid bad SQL grammar errors

## Testing
- mvn -q -DskipTests package *(fails: dependency resolution blocked by 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68db6c8e52508329893d0e2626d7659a