### PR TITLE
Update service and util tests

### DIFF
--- a/src/test/java/com/example/h2sync/util/SqlUtilsTest.java
+++ b/src/test/java/com/example/h2sync/util/SqlUtilsTest.java
@@ -1,0 +1,27 @@
+package com.example.h2sync.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SqlUtilsTest {
+
+    @Test
+    void isSafeSelectRequiresNonEmptySelectWithoutMutations() {
+        assertFalse(SqlUtils.isSafeSelect(null));
+        assertFalse(SqlUtils.isSafeSelect(""));
+        assertFalse(SqlUtils.isSafeSelect("   \n   "));
+        assertFalse(SqlUtils.isSafeSelect("DELETE FROM test"));
+        assertFalse(SqlUtils.isSafeSelect("SELECT * FROM dual;"));
+        assertFalse(SqlUtils.isSafeSelect("SELECT * FROM users WHERE name = 'drop table'"));
+        assertFalse(SqlUtils.isSafeSelect("SELECT * FROM test RUNSCRIPT from '/tmp'"));
+    }
+
+    @Test
+    void isSafeSelectAcceptsSimpleSelects() {
+        assertTrue(SqlUtils.isSafeSelect("select 1"));
+        assertTrue(SqlUtils.isSafeSelect("  \n Select * from demo where id = 1  \n"));
+        assertTrue(SqlUtils.isSafeSelect("SELECT name FROM people WHERE status = 'active'"));
+    }
+}


### PR DESCRIPTION
## Summary
- update Oracle loader service tests to reflect the new `mapType` signature and cover temporal conversion fallbacks
- add safety checks for SQL validation through dedicated `SqlUtils` unit tests

## Testing
- `mvn -q test` *(fails: dependency resolution blocked by 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920157af2648329b9a7068b13cde470)