### PR TITLE
Add scheduled H2 backups with retention and shutdown hook

### DIFF
--- a/src/main/java/com/example/h2sync/BackupRunner.java
+++ b/src/main/java/com/example/h2sync/BackupRunner.java
@@ -1,6 +1,7 @@
 package com.example.h2sync;
 
 import com.example.h2sync.service.BackupService;
+import com.example.h2sync.config.BackupProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
@@ -13,17 +14,19 @@ import java.io.File;
 public class BackupRunner implements ApplicationRunner {
     private static final Logger log = LoggerFactory.getLogger(BackupRunner.class);
     private final BackupService backupService;
+    private final BackupProperties backupProperties;
 
-    public BackupRunner(BackupService backupService) {
+    public BackupRunner(BackupService backupService, BackupProperties backupProperties) {
         this.backupService = backupService;
+        this.backupProperties = backupProperties;
     }
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
         if (args.containsOption("backup")) {
-            String dir = args.getOptionValues("backup.dir") != null ? args.getOptionValues("backup.dir").get(0) : "backups";
+            String dir = args.getOptionValues("backup.dir") != null ? args.getOptionValues("backup.dir").get(0) : backupProperties.getDir();
             String file = args.getOptionValues("backup.file") != null ? args.getOptionValues("backup.file").get(0) : null;
-            File out = backupService.backupTo(dir, file);
+            File out = backupService.backupTo(dir, file, backupProperties.getFilePrefix());
             log.info("Backup file: {}", out.getAbsolutePath());
             System.exit(0);
         }

--- a/src/main/java/com/example/h2sync/H2SyncApplication.java
+++ b/src/main/java/com/example/h2sync/H2SyncApplication.java
@@ -2,8 +2,10 @@ package com.example.h2sync;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class H2SyncApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/h2sync/config/BackupProperties.java
+++ b/src/main/java/com/example/h2sync/config/BackupProperties.java
@@ -1,0 +1,54 @@
+package com.example.h2sync.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "backup")
+public class BackupProperties {
+    private boolean enabled = true;
+    private String dir = "backups";
+    private String cron = "0 0 22 * * *";
+    private int retentionCount = 10;
+    private String filePrefix = "h2-backup";
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getDir() {
+        return dir;
+    }
+
+    public void setDir(String dir) {
+        this.dir = dir;
+    }
+
+    public String getCron() {
+        return cron;
+    }
+
+    public void setCron(String cron) {
+        this.cron = cron;
+    }
+
+    public int getRetentionCount() {
+        return retentionCount;
+    }
+
+    public void setRetentionCount(int retentionCount) {
+        this.retentionCount = retentionCount;
+    }
+
+    public String getFilePrefix() {
+        return filePrefix;
+    }
+
+    public void setFilePrefix(String filePrefix) {
+        this.filePrefix = filePrefix;
+    }
+}

--- a/src/main/java/com/example/h2sync/scheduler/BackupScheduler.java
+++ b/src/main/java/com/example/h2sync/scheduler/BackupScheduler.java
@@ -1,0 +1,60 @@
+package com.example.h2sync.scheduler;
+
+import com.example.h2sync.config.BackupProperties;
+import com.example.h2sync.service.BackupService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Component
+public class BackupScheduler {
+    private static final Logger log = LoggerFactory.getLogger(BackupScheduler.class);
+
+    private final BackupService backupService;
+    private final BackupProperties properties;
+    private final AtomicBoolean shutdownBackupTriggered = new AtomicBoolean(false);
+
+    public BackupScheduler(BackupService backupService, BackupProperties properties) {
+        this.backupService = backupService;
+        this.properties = properties;
+    }
+
+    @Scheduled(cron = "${backup.cron}")
+    public void scheduledBackup() {
+        performBackup("scheduled cron expression");
+    }
+
+    @EventListener(ContextClosedEvent.class)
+    public void onContextClosed(ContextClosedEvent event) {
+        if (!properties.isEnabled()) {
+            return;
+        }
+        if (shutdownBackupTriggered.compareAndSet(false, true)) {
+            String reason = "application shutdown (" + event.getSource().getClass().getSimpleName() + ")";
+            performBackup(reason);
+        } else {
+            log.debug("Shutdown backup already triggered; ignoring subsequent ContextClosedEvent.");
+        }
+    }
+
+    private void performBackup(String reason) {
+        if (!properties.isEnabled()) {
+            log.info("Backup skipped for '{}' because backup.enabled=false", reason);
+            return;
+        }
+        try {
+            log.info("Starting H2 backup triggered by {}", reason);
+            File out = backupService.backupTo(properties.getDir(), null, properties.getFilePrefix());
+            log.info("Backup triggered by {} completed: {}", reason, out.getAbsolutePath());
+            backupService.cleanupOldBackups(properties.getDir(), properties.getRetentionCount());
+        } catch (Exception e) {
+            log.error("Backup triggered by '{}' failed", reason, e);
+        }
+    }
+}

--- a/src/main/java/com/example/h2sync/scheduler/OracleSyncScheduler.java
+++ b/src/main/java/com/example/h2sync/scheduler/OracleSyncScheduler.java
@@ -8,14 +8,12 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
-@EnableScheduling
 public class OracleSyncScheduler implements ApplicationRunner {
     private static final Logger log = LoggerFactory.getLogger(OracleSyncScheduler.class);
 

--- a/src/main/java/com/example/h2sync/service/BackupService.java
+++ b/src/main/java/com/example/h2sync/service/BackupService.java
@@ -7,6 +7,11 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -21,6 +26,10 @@ public class BackupService {
     }
 
     public File backupTo(String targetDir, String fileName) {
+        return backupTo(targetDir, fileName, "h2-backup");
+    }
+
+    public File backupTo(String targetDir, String fileName, String filePrefix) {
         try {
             File dir = new File(targetDir);
             if (!dir.exists() && !dir.mkdirs()) {
@@ -28,7 +37,8 @@ public class BackupService {
             }
             if (fileName == null || fileName.isBlank()) {
                 String ts = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"));
-                fileName = "h2-backup-" + ts + ".zip";
+                String prefix = filePrefix == null || filePrefix.isBlank() ? "h2-backup" : filePrefix;
+                fileName = prefix + "-" + ts + ".zip";
             }
             File out = new File(dir, fileName);
             String sql = "SCRIPT TO '" + out.getAbsolutePath().replace("\\", "/") + "' COMPRESSION ZIP;";
@@ -38,6 +48,47 @@ public class BackupService {
         } catch (Exception e) {
             log.error("Backup failed", e);
             throw e;
+        }
+    }
+
+    public void cleanupOldBackups(String targetDir, int retainCount) {
+        if (retainCount < 1) {
+            log.info("Retention count is {}. Skipping cleanup for directory {}.", retainCount, targetDir);
+            return;
+        }
+
+        File dir = new File(targetDir);
+        if (!dir.exists() || !dir.isDirectory()) {
+            log.info("Backup directory {} does not exist; skipping cleanup.", targetDir);
+            return;
+        }
+
+        File[] files = dir.listFiles((d, name) -> name.toLowerCase().endsWith(".zip"));
+        if (files == null || files.length <= retainCount) {
+            log.debug("Found {} backup files in {} which is within retention count {}; no cleanup required.",
+                    files == null ? 0 : files.length, targetDir, retainCount);
+            return;
+        }
+
+        Arrays.sort(files, Comparator.comparingLong(this::getCreationTimeMillis).reversed());
+
+        for (int i = retainCount; i < files.length; i++) {
+            File file = files[i];
+            if (file.delete()) {
+                log.info("Deleted old backup file {}", file.getAbsolutePath());
+            } else {
+                log.warn("Failed to delete old backup file {}", file.getAbsolutePath());
+            }
+        }
+    }
+
+    private long getCreationTimeMillis(File file) {
+        try {
+            BasicFileAttributes attrs = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
+            return attrs.creationTime().toMillis();
+        } catch (IOException e) {
+            log.warn("Failed to read creation time for {}. Falling back to lastModified.", file.getAbsolutePath(), e);
+            return file.lastModified();
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,13 @@ loader:
   maxRetries: 3
   blacklist: ["AUDIT_LOG","SOME_BIG_TABLE_TO_SKIP"]
 
+backup:
+  enabled: true
+  dir: backups
+  cron: "0 0 22 * * *"
+  retention-count: 10
+  file-prefix: h2-backup
+
 sample:
   loader:
     h2-url: jdbc:h2:./data-sample/h2db;MODE=Oracle;DATABASE_TO_UPPER=false;AUTO_SERVER=TRUE


### PR DESCRIPTION
## Summary
- add configurable backup properties including directory, cron schedule, retention, and file prefix
- schedule nightly backups and cleanup older archives based on retention count
- trigger a final backup during graceful shutdown signals

## Testing
- mvn test (fails: repository access forbidden in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927e67d98208329a747ff150999fa1e)