### PR TITLE
Add H2 to PostgreSQL full migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
-# H2 Oracle Sync (Spring Boot 3.2.3)
+# H2 PostgreSQL Sync (Spring Boot 3.2.3)
 
 **简体中文在下面 / Chinese version below**
 
 ## EN
 
-This Spring Boot 3.2.3 service does three things:
+This Spring Boot 3.2.3 service now focuses on three things:
 
 1. **Runs an H2 database instance** and exposes it via **TCP** so that other Spring Boot services can connect over JDBC.
 2. Provides a minimal **Swagger UI** API to run **SELECT-only** queries against the H2 instance and stream results as lines with comma-separated columns.
-3. Has a **daily scheduled job** that connects to **Oracle** and performs a **full refresh** into H2 (tables, views translated into native H2 views, and sequences), with retries, multithreading, and failure logging.
+3. Publishes the existing H2 snapshot to **PostgreSQL** with full refresh, retries, failure logging and validation reporting.
+
+The old Oracle → H2 loader is retained for historical compatibility, but `loader.enabled=false` by default and it is no longer part of the active workflow.
 
 ### Why full refresh (drop & reload) daily?
 - It’s **simpler and safer** than incremental, with a much lower risk of logical errors.
-- You said the H2 data may lag Oracle by one day—this matches a daily batch.
 - No middleware is used; only direct JDBC connections.
-
-If you later insist on incremental loads, you can extend `OracleLoaderService` to track high watermarks or use change tables—but that's not required now.
 
 ### Project layout
 ```
@@ -32,14 +31,14 @@ h2-oracle-sync/
 Requirements: **JDK 17**, **Maven 3.9+**.
 
 ```bash
-# 1) Configure Oracle in src/main/resources/application.yml
-#    - oracle.url, oracle.username, oracle.password, oracle.schema
-#    - loader.blacklist for objects to skip
+# 1) Configure PostgreSQL
+#    - postgresql.url, postgresql.username, postgresql.password, postgresql.schema
+#    - set postgresql.loader.enabled=true
 
 # 2) Build
 mvn -q -DskipTests package
 
-# 3) Start the service (H2 TCP + REST + Scheduler)
+# 3) Start the service
 java -jar target/h2-oracle-sync-1.0.1.jar
 ```
 
@@ -62,7 +61,8 @@ http://localhost:8080/swagger-ui/index.html
 ```
 Response is `text/plain`, one row per line, columns joined by comma (quoted as needed). Only a **single SELECT** is allowed—no `;`, no DDL/DML.
 
-### Daily Loader (Oracle → H2)
+### Legacy Loader (Oracle → H2, disabled)
+- This was a one-time migration and is disabled by `loader.enabled=false`.
 - **Startup refresh**: automatically runs a full refresh once the application is ready, before the cron schedule kicks in.
 - **Tables**: dropped and recreated from Oracle column metadata, then bulk-inserted (batched, streaming).
 - **Views**: recreated as H2 views by translating the Oracle view SQL.
@@ -76,7 +76,31 @@ Response is `text/plain`, one row per line, columns joined by comma (quoted as n
 - `POST /api/loader/full-refresh?reason=<optional>` runs the full loader on demand without restarting Spring Boot.
 - The request blocks until the refresh finishes and returns `200 OK` on success, `409 CONFLICT` if another refresh is running, `503` when the loader is disabled.
 
+### Full Refresh (H2 → PostgreSQL)
+
+- Disabled by default. Configure the `postgresql.*` connection and set `postgresql.loader.enabled=true`.
+- **Tables and data**: recreates columns and mapped PostgreSQL types, nullability, defaults, identity/generated columns, primary keys and unique constraints; rows are streamed in configurable batches.
+- **H2 protection**: H2 full-table reads use `source-read-threads=1` by default; PostgreSQL-only constraint/index work uses a separate `target-threads` pool.
+- **LOBs**: BLOB/CLOB values are streamed one row at a time instead of retaining a whole JDBC batch in heap.
+- **Bulk-load order**: table rows are loaded before primary keys, unique constraints and indexes are created. The JDBC URL enables `reWriteBatchedInserts` for non-LOB rows.
+- **Sequences**: recreates increment/range/cycle/cache settings and aligns PostgreSQL's next value with H2 `BASE_VALUE`.
+- **Indexes**: recreates ordinary and unique indexes after data loading. Indexes already represented by primary-key/unique constraints are not duplicated.
+- **Foreign keys**: recreates same-schema foreign keys after every table is loaded.
+- **Views**: remaps the H2 source schema to the PostgreSQL target schema, translates common compatibility tokens (`NVL`, `IFNULL`, `SYSDATE`, `MINUS`), and retries views in dependency order.
+- **Reliability**: supports per-object retries, case-insensitive blacklist entries and a PostgreSQL failure table named `H2_PG_ETL_FAIL_LOG`. Any terminal object failure makes the whole run fail after the report is printed.
+- **Validation output**: logs an H2/PostgreSQL comparison report for table row counts, constraints, view/index/foreign-key presence and sequence next values.
+- **Schedule**: defaults to 03:30 Asia/Shanghai.
+
+Manual trigger:
+
+```text
+POST /api/postgresql-loader/full-refresh?reason=<optional>
+```
+
+The call blocks and returns `200 OK` after the refresh, `409 CONFLICT` if a PostgreSQL refresh is already running, `500` if any object ultimately fails, or `503` when `postgresql.loader.enabled=false`.
+
 ### Sample Loader (100-row snapshot)
+- Disabled by default with `sample.loader.enabled=false` because it also depends on Oracle.
 - `GET /api/sample-loader/refresh` builds a separate H2 database using `sample.loader.h2-url`.
 - Each Oracle table contributes up to **100 rows** (or fewer if the table is smaller), while views and sequences are recreated one-to-one.
 - Useful when you only need lightweight fixtures without cloning the full dataset. Triggered manually; no scheduler runs it automatically.
@@ -94,40 +118,38 @@ RUNSCRIPT FROM 'backups/h2-backup.zip';
 ```
 
 ### Notes / Limitations
-- Data type mapping is simplified but covers common Oracle types. Tune `mapType()` if needed.
-- Primary keys, indexes, constraints are not copied in this minimal baseline.
-- Views are created directly in H2 using translated Oracle SQL.
-- `user_sequences.last_number` is the **next** value in Oracle; we align H2 to that to avoid duplicates.
+- Data type mapping covers the H2 types produced by the original import and common native H2 types. Tune `mapType()` for additional vendor-specific types.
+- Oracle → H2 currently copies primary keys, unique constraints and nullability, but does not copy ordinary Oracle indexes or foreign keys. H2 → PostgreSQL copies the complete structure that exists in H2, including its ordinary indexes and same-schema foreign keys.
+- PostgreSQL 12+ is recommended. Highly vendor-specific H2 view expressions may still need an additional rule in `H2ToPostgresqlViewSqlTranslator`.
 
 ---
 
 ## 中文 (CN)
 
-这个 Spring Boot 3.2.3 服务包含：
+这个 Spring Boot 3.2.3 服务现在聚焦于：
 
 1. **启动一个 H2 数据库实例**，通过 **TCP** 对外提供 JDBC 连接（供其它 Spring Boot 服务连接）。
 2. 提供一个极简 **Swagger UI** API（只允许 **SELECT**），把查询结果按“每行一条、列用逗号分隔”的文本流返回。
-3. 带有一个**每日定时任务**，连接 **Oracle**，把数据 **全量刷新** 到 H2（包含表、**视图转换为 H2 原生视图**、序列），并且有重试、多线程和失败记录。
+3. 把现有 H2 快照**全量发布到 PostgreSQL**，并提供重试、失败日志和迁移校验报告。
+
+Oracle → H2 属于已经完成的一次性历史功能，代码继续保留，但默认配置为 `loader.enabled=false`，不再参与当前流程。
 
 ### 为何选择每日 **全量**（drop + reload）？
 - **更简单、更稳妥**，出错概率低。
-- 你的要求是 H2 相比 Oracle **延迟一天**，每日批量刚好匹配。
 - **不使用任何中间件**，仅 JDBC。
-
-如果以后一定要增量，再给 `OracleLoaderService` 增加高水位或变更表逻辑即可；目前不需要。
 
 ### 构建与运行
 环境：**JDK 17**、**Maven 3.9+**。
 
 ```bash
-# 1）修改配置：src/main/resources/application.yml
-#    - oracle.url / oracle.username / oracle.password / oracle.schema
-#    - loader.blacklist 黑名单列表
+# 1）配置 H2 → PostgreSQL：
+#    - postgresql.url / postgresql.username / postgresql.password / postgresql.schema
+#    - postgresql.loader.enabled=true
 
 # 2）打包
 mvn -q -DskipTests package
 
-# 3）启动（H2 TCP + REST + 定时器）
+# 3）启动
 java -jar target/h2-oracle-sync-1.0.1.jar
 ```
 
@@ -147,7 +169,8 @@ Swagger：`http://localhost:8080/swagger-ui/index.html`
 ```
 返回 `text/plain`，**一行一条**，**列用逗号分隔**（必要时会加引号）。**只允许单条 SELECT**，禁止 `;` 与任何 DDL/DML。
 
-### 每日装载（Oracle → H2）
+### 历史装载（Oracle → H2，已停用）
+- 这是已经完成的一次性迁移，默认 `loader.enabled=false`。
 - **启动即刷新**：Spring Boot 完全就绪后会立即执行一次全量刷新，然后再按 cron 定时。
 - **表**：根据 Oracle 列元数据在 H2 里**重建表结构**，然后批量写入（流式 + 批处理）。
 - **视图**：把 Oracle 的视图 SQL 翻译后直接在 H2 中创建同名视图。
@@ -161,7 +184,31 @@ Swagger：`http://localhost:8080/swagger-ui/index.html`
 - `POST /api/loader/full-refresh?reason=<可选说明>` 可以在不重启 Spring Boot 的情况下随时触发全量。
 - 接口会在全量完成后返回：成功 `200 OK`，若已有任务在跑返回 `409 CONFLICT`，若 loader 被禁用则返回 `503`。
 
+### 全量发布（H2 → PostgreSQL）
+
+- 默认关闭；先配置 `postgresql.*`，再设置 `postgresql.loader.enabled=true`。
+- **表和数据**：重建列及 PostgreSQL 类型、非空、默认值、自增/生成列、主键、唯一约束，然后按批次流式写入全部数据。
+- **保护 H2**：H2 全表读取默认 `source-read-threads=1`；仅 PostgreSQL 侧的约束和索引使用独立的 `target-threads` 并行池。
+- **LOB**：BLOB/CLOB 按行流式发送，不再把整个 JDBC 批次的 LOB 全部保留在堆内存中。
+- **全量写入顺序**：先写数据，再创建主键、唯一约束和索引；非 LOB 数据启用 PostgreSQL `reWriteBatchedInserts`。
+- **序列**：迁移步长、上下限、循环、缓存，并用 H2 `BASE_VALUE` 对齐 PostgreSQL 的下一个值。
+- **索引**：数据完成后创建普通索引和唯一索引；主键/唯一约束已经隐含的索引不会重复创建。
+- **外键**：所有表完成后创建同一 H2 schema 内的外键及更新/删除规则。
+- **视图**：把 H2 source schema 映射到 PostgreSQL target schema，转换常见兼容语法（`NVL`、`IFNULL`、`SYSDATE`、`MINUS`），并按依赖关系重试。
+- **可靠性**：对象级重试、大小写不敏感黑名单；失败写入 PostgreSQL 的 `H2_PG_ETL_FAIL_LOG`。任何对象最终失败，报告仍会输出，但整体任务返回失败。
+- **最终校验**：日志输出 H2/PostgreSQL 对比报告，逐项检查表行数、主键/唯一约束、视图、索引、外键和序列下一个值。
+- **定时任务**：默认是上海时区每天 03:30。
+
+手动触发：
+
+```text
+POST /api/postgresql-loader/full-refresh?reason=<可选说明>
+```
+
+接口阻塞到执行完成：成功返回 `200`，已有任务运行返回 `409`，任何对象最终失败返回 `500`，`postgresql.loader.enabled=false` 返回 `503`。
+
 ### 100 条样例装载
+- 该功能同样依赖 Oracle，默认 `sample.loader.enabled=false`，不会创建对应 Bean 和接口。
 - `GET /api/sample-loader/refresh` 会按 `sample.loader.h2-url` 构建一个**独立**的 H2 数据库。
 - 每张 Oracle 表最多取 **100 行**（如果不足 100 行则全部取），视图与序列也会对应创建。
 - 适用于只需要轻量数据样本的场景，完全手动触发，不会随应用启动或定时任务自动执行。
@@ -179,10 +226,9 @@ RUNSCRIPT FROM 'backups/h2-backup.zip';
 ```
 
 ### 注意事项
-- 类型映射做了适度简化，覆盖常见 Oracle 类型，必要时可在 `mapType()` 微调。
-- 本版本不复制主键、索引、约束（如需请后续扩展）。
-- 视图直接在 H2 中根据翻译后的 Oracle SQL 创建。
-- Oracle 的 `user_sequences.last_number` 表示**下一个**值；H2 也对齐到这个值，避免重复。
+- 类型映射覆盖原迁移生成的 H2 类型及常见原生 H2 类型，额外的厂商特有类型可在 `mapType()` 中扩展。
+- Oracle → H2 当前会复制主键、唯一约束和非空属性，但不复制 Oracle 普通索引和外键；H2 → PostgreSQL 会复制 H2 中实际存在的完整结构，包括普通索引和同 schema 外键。
+- 建议使用 PostgreSQL 12+；极少数 H2/Oracle 特有视图表达式可能仍需在 `H2ToPostgresqlViewSqlTranslator` 增加转换规则。
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
   <groupId>com.example</groupId>
   <artifactId>h2-oracle-sync</artifactId>
   <version>1.0.1</version>
-  <name>h2-oracle-sync</name>
-  <description>Spring Boot 3.2.3 service that runs an H2 TCP server and daily loads data from Oracle</description>
+  <name>h2-postgresql-sync</name>
+  <description>Spring Boot service that publishes an existing H2 database to PostgreSQL</description>
   <properties>
     <java.version>17</java.version>
     <spring.boot.version>3.2.3</spring.boot.version>
@@ -44,6 +44,11 @@
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc11</artifactId>
       <version>23.4.0.24.05</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/h2sync/controller/H2PostgresqlLoaderController.java
+++ b/src/main/java/com/example/h2sync/controller/H2PostgresqlLoaderController.java
@@ -1,0 +1,51 @@
+package com.example.h2sync.controller;
+
+import com.example.h2sync.scheduler.H2PostgresqlSyncScheduler;
+import com.example.h2sync.scheduler.H2PostgresqlSyncScheduler.TriggerResult;
+import com.example.h2sync.service.H2ToPostgresqlLoaderService.MigrationIncompleteException;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/postgresql-loader")
+public class H2PostgresqlLoaderController {
+
+    private final H2PostgresqlSyncScheduler scheduler;
+
+    public H2PostgresqlLoaderController(H2PostgresqlSyncScheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    @Operation(
+            summary = "Trigger a full H2-to-PostgreSQL load",
+            description = "Rebuilds tables and data, sequences, indexes, foreign keys and views, then prints a validation report."
+    )
+    @PostMapping("/full-refresh")
+    public ResponseEntity<String> triggerFullRefresh(
+            @RequestParam(value = "reason", required = false) String reason
+    ) {
+        String triggerReason = reason == null || reason.isBlank()
+                ? "manual API request"
+                : "manual API request: " + reason;
+        TriggerResult result;
+        try {
+            result = scheduler.triggerFullRefresh(triggerReason);
+        } catch (MigrationIncompleteException ex) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("H2 -> PostgreSQL refresh finished with " + ex.getFailureCount() +
+                            " failed objects. Check H2_PG_ETL_FAIL_LOG and the migration report.");
+        }
+        return switch (result) {
+            case STARTED -> ResponseEntity.ok("H2 -> PostgreSQL full refresh completed successfully.");
+            case ALREADY_RUNNING -> ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body("H2 -> PostgreSQL refresh skipped because another run is still in progress.");
+            case DISABLED -> ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body("H2 -> PostgreSQL refresh skipped because postgresql.loader.enabled=false.");
+        };
+    }
+}

--- a/src/main/java/com/example/h2sync/controller/LoaderController.java
+++ b/src/main/java/com/example/h2sync/controller/LoaderController.java
@@ -3,6 +3,7 @@ package com.example.h2sync.controller;
 import com.example.h2sync.scheduler.OracleSyncScheduler;
 import com.example.h2sync.scheduler.OracleSyncScheduler.TriggerResult;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/loader")
+@ConditionalOnProperty(prefix = "loader", name = "enabled", havingValue = "true")
 public class LoaderController {
 
     private final OracleSyncScheduler scheduler;

--- a/src/main/java/com/example/h2sync/controller/SampleLoaderController.java
+++ b/src/main/java/com/example/h2sync/controller/SampleLoaderController.java
@@ -2,6 +2,7 @@ package com.example.h2sync.controller;
 
 import com.example.h2sync.service.OracleSampleLoaderService;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @RestController
 @RequestMapping("/api/sample-loader")
+@ConditionalOnProperty(prefix = "sample.loader", name = "enabled", havingValue = "true")
 public class SampleLoaderController {
 
     private final OracleSampleLoaderService sampleLoaderService;

--- a/src/main/java/com/example/h2sync/scheduler/H2PostgresqlSyncScheduler.java
+++ b/src/main/java/com/example/h2sync/scheduler/H2PostgresqlSyncScheduler.java
@@ -1,12 +1,11 @@
 package com.example.h2sync.scheduler;
 
-import com.example.h2sync.service.OracleLoaderService;
+import com.example.h2sync.service.H2ToPostgresqlLoaderService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -15,12 +14,13 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Component
-@ConditionalOnProperty(prefix = "loader", name = "enabled", havingValue = "true")
-public class OracleSyncScheduler implements ApplicationRunner {
-    private static final Logger log = LoggerFactory.getLogger(OracleSyncScheduler.class);
+public class H2PostgresqlSyncScheduler implements ApplicationRunner {
 
-    private final OracleLoaderService loader;
+    private static final Logger log = LoggerFactory.getLogger(H2PostgresqlSyncScheduler.class);
+
+    private final H2ToPostgresqlLoaderService loader;
     private final boolean enabled;
+    private final boolean startupEnabled;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicBoolean startupTriggered = new AtomicBoolean(false);
     private volatile String startupReason = "application startup";
@@ -31,43 +31,54 @@ public class OracleSyncScheduler implements ApplicationRunner {
         DISABLED
     }
 
-    public OracleSyncScheduler(OracleLoaderService loader,
-                               @Value("${loader.enabled:true}") boolean enabled) {
+    public H2PostgresqlSyncScheduler(
+            H2ToPostgresqlLoaderService loader,
+            @Value("${postgresql.loader.enabled:false}") boolean enabled,
+            @Value("${postgresql.loader.startup:true}") boolean startupEnabled
+    ) {
         this.loader = loader;
         this.enabled = enabled;
+        this.startupEnabled = startupEnabled;
     }
 
-    @Scheduled(cron = "${loader.cron}")
+    @Scheduled(
+            cron = "${postgresql.loader.cron:0 30 3 * * *}",
+            zone = "${postgresql.loader.zone:Asia/Shanghai}"
+    )
     public void scheduled() {
         triggerFullRefresh("scheduled cron expression");
     }
 
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady() {
+        if (!startupEnabled) {
+            log.info("H2 -> PostgreSQL startup refresh skipped because postgresql.loader.startup=false");
+            return;
+        }
         triggerStartupRefresh(startupReason);
     }
 
     @Override
-    public void run(ApplicationArguments args) throws Exception {
-        if (args.containsOption("runOnce")) {
-            startupReason = "runOnce command-line flag";
-            log.info("runOnce flag detected; scheduling startup full refresh once the application is ready.");
+    public void run(ApplicationArguments args) {
+        if (args.containsOption("postgresqlRunOnce")) {
+            startupReason = "postgresqlRunOnce command-line flag";
+            log.info("postgresqlRunOnce flag detected; H2 -> PostgreSQL refresh will run when the application is ready.");
         }
     }
 
     public TriggerResult triggerFullRefresh(String reason) {
         if (!enabled) {
-            log.info("Full refresh trigger '{}' skipped because loader.enabled=false", reason);
+            log.info("H2 -> PostgreSQL trigger '{}' skipped because postgresql.loader.enabled=false", reason);
             return TriggerResult.DISABLED;
         }
         if (!running.compareAndSet(false, true)) {
-            log.info("Full refresh trigger '{}' skipped because another refresh is already running", reason);
+            log.info("H2 -> PostgreSQL trigger '{}' skipped because another refresh is running", reason);
             return TriggerResult.ALREADY_RUNNING;
         }
         try {
-            log.info("Starting full refresh (triggered by {}).", reason);
+            log.info("Starting H2 -> PostgreSQL full refresh (triggered by {}).", reason);
             loader.runFullRefresh();
-            log.info("Full refresh triggered by '{}' finished successfully.", reason);
+            log.info("H2 -> PostgreSQL refresh triggered by '{}' finished successfully.", reason);
             return TriggerResult.STARTED;
         } finally {
             running.set(false);
@@ -76,12 +87,9 @@ public class OracleSyncScheduler implements ApplicationRunner {
 
     private void triggerStartupRefresh(String reason) {
         if (!startupTriggered.compareAndSet(false, true)) {
-            log.debug("Startup full refresh already triggered; skipping '{}'.", reason);
+            log.debug("H2 -> PostgreSQL startup refresh already triggered; skipping '{}'.", reason);
             return;
         }
-        TriggerResult result = triggerFullRefresh(reason);
-        if (result == TriggerResult.ALREADY_RUNNING) {
-            log.info("Startup full refresh '{}' is already handled by another trigger.", reason);
-        }
+        triggerFullRefresh(reason);
     }
 }

--- a/src/main/java/com/example/h2sync/service/H2ToPostgresqlLoaderService.java
+++ b/src/main/java/com/example/h2sync/service/H2ToPostgresqlLoaderService.java
@@ -1,0 +1,1500 @@
+package com.example.h2sync.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Full-refresh migration from the application's H2 database to PostgreSQL.
+ * Tables are rebuilt and streamed first, followed by indexes, foreign keys and
+ * dependency-ordered views. Explicit sequences are recreated at their H2 next
+ * value before table DDL is applied so sequence-backed defaults remain valid.
+ */
+@Service
+public class H2ToPostgresqlLoaderService {
+
+    private static final Logger log = LoggerFactory.getLogger(H2ToPostgresqlLoaderService.class);
+    private static final String FAILURE_TABLE = "H2_PG_ETL_FAIL_LOG";
+    private static final int POSTGRESQL_MAX_VARCHAR_LENGTH = 10_485_760;
+    private static final Pattern NEXT_VALUE_PATTERN = Pattern.compile(
+            "(?i)^NEXT\\s+VALUE\\s+FOR\\s+(?:(?:\\\"([^\\\"]+)\\\"|([A-Z0-9_$#]+))\\s*\\.\\s*)?(?:\\\"([^\\\"]+)\\\"|([A-Z0-9_$#]+))$"
+    );
+
+    private final JdbcTemplate source;
+    private final DataSource sourceDataSource;
+    private final JdbcTemplate target;
+    private final DataSource targetDataSource;
+    private final String sourceSchema;
+    private final String targetSchema;
+    private final int sourceReadThreads;
+    private final int targetThreads;
+    private final int batchSize;
+    private final int maxRetries;
+    private final Set<String> blacklist;
+    private final H2ToPostgresqlViewSqlTranslator viewSqlTranslator;
+    private final H2ToPostgresqlMigrationReportPrinter reportPrinter;
+    private final boolean h2TestTarget;
+
+    public H2ToPostgresqlLoaderService(
+            JdbcTemplate source,
+            @Value("${postgresql.driver-class:org.postgresql.Driver}") String driverClass,
+            @Value("${postgresql.url:jdbc:postgresql://localhost:5432/YOUR_DATABASE}") String url,
+            @Value("${postgresql.username:YOUR_POSTGRESQL_USER}") String user,
+            @Value("${postgresql.password:YOUR_POSTGRESQL_PASSWORD}") String pass,
+            @Value("${postgresql.schema:public}") String targetSchema,
+            @Value("${postgresql.loader.source-schema:PUBLIC}") String sourceSchema,
+            @Value("${postgresql.loader.source-read-threads:1}") int sourceReadThreads,
+            @Value("${postgresql.loader.target-threads:4}") int targetThreads,
+            @Value("${postgresql.loader.batchSize:${loader.batchSize:1000}}") int batchSize,
+            @Value("${postgresql.loader.maxRetries:${loader.maxRetries:3}}") int maxRetries,
+            @Value("#{'${postgresql.loader.blacklist:}'.replace('[','').replace(']','')}") String blacklistCsv
+    ) {
+        this(
+                source,
+                Objects.requireNonNull(source.getDataSource(), "H2 source DataSource is required"),
+                createPostgresqlDataSource(driverClass, url, user, pass),
+                sourceSchema,
+                targetSchema,
+                sourceReadThreads,
+                targetThreads,
+                batchSize,
+                maxRetries,
+                blacklistCsv
+        );
+    }
+
+    H2ToPostgresqlLoaderService(
+            JdbcTemplate source,
+            DataSource sourceDataSource,
+            DataSource targetDataSource,
+            String sourceSchema,
+            String targetSchema,
+            int sourceReadThreads,
+            int targetThreads,
+            int batchSize,
+            int maxRetries,
+            String blacklistCsv
+    ) {
+        this.source = Objects.requireNonNull(source, "source");
+        this.sourceDataSource = Objects.requireNonNull(sourceDataSource, "sourceDataSource");
+        this.targetDataSource = Objects.requireNonNull(targetDataSource, "targetDataSource");
+        this.target = new JdbcTemplate(targetDataSource);
+        this.sourceSchema = requireIdentifier(sourceSchema, "sourceSchema");
+        this.targetSchema = requireIdentifier(targetSchema, "targetSchema");
+        this.sourceReadThreads = Math.max(1, sourceReadThreads);
+        this.targetThreads = Math.max(1, targetThreads);
+        this.batchSize = Math.max(1, batchSize);
+        this.maxRetries = Math.max(1, maxRetries);
+        this.blacklist = parseBlacklist(blacklistCsv);
+        this.viewSqlTranslator = new H2ToPostgresqlViewSqlTranslator(this.sourceSchema, this.targetSchema);
+        this.h2TestTarget = detectH2Target(targetDataSource);
+        this.reportPrinter = new H2ToPostgresqlMigrationReportPrinter(
+                log,
+                source,
+                target,
+                targetDataSource,
+                this.sourceSchema,
+                this.targetSchema,
+                this::isBlacklisted,
+                this.h2TestTarget
+        );
+    }
+
+    private static DataSource createPostgresqlDataSource(String driverClass, String url, String user, String pass) {
+        DriverManagerDataSource ds = new DriverManagerDataSource();
+        ds.setDriverClassName(driverClass == null || driverClass.isBlank()
+                ? "org.postgresql.Driver"
+                : driverClass);
+        ds.setUrl(url);
+        ds.setUsername(user);
+        ds.setPassword(pass);
+        if (url != null && url.toLowerCase(Locale.ROOT).startsWith("jdbc:postgresql:")) {
+            Properties properties = new Properties();
+            properties.setProperty("reWriteBatchedInserts", "true");
+            ds.setConnectionProperties(properties);
+        }
+        return ds;
+    }
+
+    public void runFullRefresh() {
+        log.info("Starting H2 -> PostgreSQL full refresh. sourceReadThreads={}, targetThreads={}, " +
+                        "batchSize={}, sourceSchema={}, targetSchema={}, blacklist={}",
+                sourceReadThreads, targetThreads, batchSize, sourceSchema, targetSchema, blacklist);
+        if (sourceReadThreads > 2) {
+            log.warn("postgresql.loader.source-read-threads={} may put excessive I/O pressure on embedded H2; " +
+                    "1 is recommended unless file-based benchmarks show a benefit", sourceReadThreads);
+        }
+        long started = System.currentTimeMillis();
+
+        MigrationSnapshot snapshot = readSourceSnapshot();
+        initializeTarget();
+        dropSourceViewsFromTarget(snapshot.views().keySet());
+        List<MigrationFailure> failures = new CopyOnWriteArrayList<>();
+        Set<String> successfulTables = ConcurrentHashMap.newKeySet();
+
+        for (SequenceDefinition sequence : snapshot.sequences()) {
+            if (!isBlacklisted(sequence.name())) {
+                retry(() -> syncSequence(sequence), "SEQUENCE", sequence.name(), failures);
+            }
+        }
+
+        List<Future<?>> futures = new ArrayList<>();
+        ExecutorService sourcePool = Executors.newFixedThreadPool(sourceReadThreads);
+        try {
+            for (TableDefinition table : snapshot.tables().values()) {
+                futures.add(sourcePool.submit(() -> {
+                    if (retry(() -> copyTable(table), "TABLE", table.name(), failures)) {
+                        successfulTables.add(table.name());
+                    }
+                }));
+            }
+            waitForFutures(futures, "table", failures);
+        } finally {
+            sourcePool.shutdown();
+        }
+
+        ExecutorService targetPool = Executors.newFixedThreadPool(targetThreads);
+        try {
+            for (TableDefinition table : snapshot.tables().values()) {
+                if (!successfulTables.contains(table.name())) continue;
+                futures.add(targetPool.submit(() -> {
+                    if (table.primaryKey() != null) {
+                        ConstraintDefinition primaryKey = table.primaryKey();
+                        retry(
+                                () -> syncPrimaryKey(table, primaryKey),
+                                "PRIMARY_KEY",
+                                table.name() + "." + primaryKey.name(),
+                                failures
+                        );
+                    }
+                    for (ConstraintDefinition unique : table.uniqueConstraints()) {
+                        retry(
+                                () -> syncUniqueConstraint(table, unique),
+                                "UNIQUE",
+                                table.name() + "." + unique.name(),
+                                failures
+                        );
+                    }
+                }));
+            }
+            waitForFutures(futures, "constraint", failures);
+
+            for (TableDefinition table : snapshot.tables().values()) {
+                if (!successfulTables.contains(table.name())) continue;
+                for (IndexDefinition index : table.indexes()) {
+                    String objectName = table.name() + "." + index.name();
+                    futures.add(targetPool.submit(() -> retry(
+                            () -> syncIndex(table, index), "INDEX", objectName, failures)));
+                }
+            }
+            waitForFutures(futures, "index", failures);
+        } finally {
+            targetPool.shutdown();
+        }
+
+        for (TableDefinition table : snapshot.tables().values()) {
+            if (!successfulTables.contains(table.name())) continue;
+            for (ForeignKeyDefinition foreignKey : table.foreignKeys()) {
+                String objectName = table.name() + "." + foreignKey.name();
+                if (!isSourceSchema(foreignKey.referencedSchema())
+                        || isBlacklisted(foreignKey.referencedTable())
+                        || !successfulTables.contains(foreignKey.referencedTable())) {
+                    log.warn("Skipping foreign key {} because referenced table {}.{} is not in the successful migration set",
+                            objectName, foreignKey.referencedSchema(), foreignKey.referencedTable());
+                    continue;
+                }
+                retry(() -> syncForeignKey(table, foreignKey), "FOREIGN_KEY", objectName, failures);
+            }
+        }
+
+        syncViewsWithDependencyAwareness(snapshot.views(), failures);
+
+        try {
+            reportPrinter.printReport(snapshot);
+        } catch (Exception ex) {
+            log.warn("Failed to generate H2 -> PostgreSQL migration report: {}", ex.toString());
+            log.debug("H2 -> PostgreSQL report failure", ex);
+        }
+        long took = System.currentTimeMillis() - started;
+        if (!failures.isEmpty()) {
+            log.error("H2 -> PostgreSQL full refresh completed with {} failed objects in {} ms", failures.size(), took);
+            throw new MigrationIncompleteException(failures);
+        }
+        log.info("H2 -> PostgreSQL full refresh completed in {} ms", took);
+    }
+
+    private MigrationSnapshot readSourceSnapshot() {
+        try (Connection connection = sourceDataSource.getConnection()) {
+            Set<String> tableNames = listTables(connection);
+            Set<String> viewNames = listViews(connection);
+            List<SequenceDefinition> sequences = listSequences(connection);
+
+            Map<String, TableDefinition> tables = new LinkedHashMap<>();
+            for (String tableName : tableNames) {
+                if (!isBlacklisted(tableName)) {
+                    tables.put(tableName, loadTableDefinition(connection, tableName));
+                }
+            }
+
+            Map<String, ViewDefinition> views = new LinkedHashMap<>();
+            for (String viewName : viewNames) {
+                if (!isBlacklisted(viewName)) {
+                    views.put(viewName, loadViewDefinition(connection, viewName));
+                }
+            }
+            return new MigrationSnapshot(tableNames, viewNames, tables, views, sequences);
+        } catch (SQLException ex) {
+            throw new RuntimeException("Failed to inspect H2 schema " + sourceSchema, ex);
+        }
+    }
+
+    private Set<String> listTables(Connection connection) throws SQLException {
+        String sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES " +
+                "WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE' ORDER BY TABLE_NAME";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, sourceSchema);
+            try (ResultSet rs = ps.executeQuery()) {
+                Set<String> result = new TreeSet<>();
+                while (rs.next()) {
+                    result.add(rs.getString(1));
+                }
+                log.info("Found {} tables in H2 schema {}", result.size(), sourceSchema);
+                return result;
+            }
+        }
+    }
+
+    private Set<String> listViews(Connection connection) throws SQLException {
+        String sql = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = ? ORDER BY TABLE_NAME";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, sourceSchema);
+            try (ResultSet rs = ps.executeQuery()) {
+                Set<String> result = new TreeSet<>();
+                while (rs.next()) {
+                    result.add(rs.getString(1));
+                }
+                log.info("Found {} views in H2 schema {}", result.size(), sourceSchema);
+                return result;
+            }
+        }
+    }
+
+    private List<SequenceDefinition> listSequences(Connection connection) throws SQLException {
+        String sql = "SELECT SEQUENCE_NAME, INCREMENT, BASE_VALUE, MINIMUM_VALUE, MAXIMUM_VALUE, " +
+                "CYCLE_OPTION, CACHE FROM INFORMATION_SCHEMA.SEQUENCES " +
+                "WHERE SEQUENCE_SCHEMA = ? ORDER BY SEQUENCE_NAME";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, sourceSchema);
+            try (ResultSet rs = ps.executeQuery()) {
+                List<SequenceDefinition> result = new ArrayList<>();
+                while (rs.next()) {
+                    result.add(new SequenceDefinition(
+                            rs.getString("SEQUENCE_NAME"),
+                            rs.getBigDecimal("INCREMENT"),
+                            rs.getBigDecimal("BASE_VALUE"),
+                            rs.getBigDecimal("MINIMUM_VALUE"),
+                            rs.getBigDecimal("MAXIMUM_VALUE"),
+                            "YES".equalsIgnoreCase(rs.getString("CYCLE_OPTION")),
+                            rs.getLong("CACHE")
+                    ));
+                }
+                log.info("Found {} sequences in H2 schema {}", result.size(), sourceSchema);
+                return result;
+            }
+        }
+    }
+
+    private TableDefinition loadTableDefinition(Connection connection, String table) throws SQLException {
+        DatabaseMetaData metadata = connection.getMetaData();
+        Map<String, ColumnExtras> columnExtras = fetchColumnExtras(connection, table);
+        List<ColumnDefinition> columns = new ArrayList<>();
+        try (ResultSet rs = metadata.getColumns(connection.getCatalog(), sourceSchema, table, null)) {
+            while (rs.next()) {
+                String name = rs.getString("COLUMN_NAME");
+                ColumnExtras extras = columnExtras.getOrDefault(name, ColumnExtras.EMPTY);
+                columns.add(new ColumnDefinition(
+                        name,
+                        rs.getInt("DATA_TYPE"),
+                        rs.getString("TYPE_NAME"),
+                        rs.getInt("COLUMN_SIZE"),
+                        rs.getInt("DECIMAL_DIGITS"),
+                        rs.getInt("NULLABLE") != DatabaseMetaData.columnNoNulls,
+                        "YES".equalsIgnoreCase(safeGetString(rs, "IS_AUTOINCREMENT")),
+                        "YES".equalsIgnoreCase(safeGetString(rs, "IS_GENERATEDCOLUMN")),
+                        rs.getString("COLUMN_DEF"),
+                        extras.generationExpression(),
+                        extras.identityStart(),
+                        extras.identityIncrement(),
+                        extras.identityMinimum(),
+                        extras.identityMaximum(),
+                        extras.identityBase(),
+                        extras.identityCycle(),
+                        extras.identityCache()
+                ));
+            }
+        }
+        ConstraintDefinition primaryKey = fetchPrimaryKey(metadata, connection, table);
+        List<ConstraintDefinition> uniqueConstraints = fetchUniqueConstraints(connection, table);
+        List<IndexDefinition> indexes = fetchIndexes(metadata, connection, table, primaryKey, uniqueConstraints);
+        List<ForeignKeyDefinition> foreignKeys = fetchForeignKeys(metadata, connection, table);
+        return new TableDefinition(table, columns, primaryKey, uniqueConstraints, indexes, foreignKeys);
+    }
+
+    private Map<String, ColumnExtras> fetchColumnExtras(Connection connection, String table) throws SQLException {
+        String sql = "SELECT COLUMN_NAME, GENERATION_EXPRESSION, IDENTITY_START, IDENTITY_INCREMENT, " +
+                "IDENTITY_MINIMUM, IDENTITY_MAXIMUM, IDENTITY_BASE, IDENTITY_CYCLE, IDENTITY_CACHE " +
+                "FROM INFORMATION_SCHEMA.COLUMNS " +
+                "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, sourceSchema);
+            ps.setString(2, table);
+            try (ResultSet rs = ps.executeQuery()) {
+                Map<String, ColumnExtras> result = new HashMap<>();
+                while (rs.next()) {
+                    result.put(rs.getString("COLUMN_NAME"), new ColumnExtras(
+                            rs.getString("GENERATION_EXPRESSION"),
+                            rs.getBigDecimal("IDENTITY_START"),
+                            rs.getBigDecimal("IDENTITY_INCREMENT"),
+                            rs.getBigDecimal("IDENTITY_MINIMUM"),
+                            rs.getBigDecimal("IDENTITY_MAXIMUM"),
+                            rs.getBigDecimal("IDENTITY_BASE"),
+                            "YES".equalsIgnoreCase(rs.getString("IDENTITY_CYCLE")),
+                            rs.getLong("IDENTITY_CACHE")
+                    ));
+                }
+                return result;
+            }
+        }
+    }
+
+    private ConstraintDefinition fetchPrimaryKey(DatabaseMetaData metadata, Connection connection, String table)
+            throws SQLException {
+        Map<Integer, String> columns = new LinkedHashMap<>();
+        String name = null;
+        try (ResultSet rs = metadata.getPrimaryKeys(connection.getCatalog(), sourceSchema, table)) {
+            while (rs.next()) {
+                name = rs.getString("PK_NAME");
+                columns.put(rs.getInt("KEY_SEQ"), rs.getString("COLUMN_NAME"));
+            }
+        }
+        if (columns.isEmpty()) {
+            return null;
+        }
+        String resolvedName = name == null || name.isBlank() ? "PK_" + table : name;
+        return new ConstraintDefinition(resolvedName, orderedValues(columns));
+    }
+
+    private List<ConstraintDefinition> fetchUniqueConstraints(Connection connection, String table) throws SQLException {
+        String sql = "SELECT TC.CONSTRAINT_NAME, KCU.COLUMN_NAME, KCU.ORDINAL_POSITION " +
+                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS TC " +
+                "JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE KCU " +
+                "ON TC.CONSTRAINT_CATALOG = KCU.CONSTRAINT_CATALOG " +
+                "AND TC.CONSTRAINT_SCHEMA = KCU.CONSTRAINT_SCHEMA " +
+                "AND TC.CONSTRAINT_NAME = KCU.CONSTRAINT_NAME " +
+                "WHERE TC.TABLE_SCHEMA = ? AND TC.TABLE_NAME = ? AND TC.CONSTRAINT_TYPE = 'UNIQUE' " +
+                "ORDER BY TC.CONSTRAINT_NAME, KCU.ORDINAL_POSITION";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, sourceSchema);
+            ps.setString(2, table);
+            try (ResultSet rs = ps.executeQuery()) {
+                Map<String, List<String>> constraints = new LinkedHashMap<>();
+                while (rs.next()) {
+                    constraints.computeIfAbsent(rs.getString(1), ignored -> new ArrayList<>()).add(rs.getString(2));
+                }
+                return constraints.entrySet().stream()
+                        .map(entry -> new ConstraintDefinition(entry.getKey(), entry.getValue()))
+                        .toList();
+            }
+        }
+    }
+
+    private List<IndexDefinition> fetchIndexes(
+            DatabaseMetaData metadata,
+            Connection connection,
+            String table,
+            ConstraintDefinition primaryKey,
+            List<ConstraintDefinition> uniqueConstraints
+    ) throws SQLException {
+        Map<String, MutableIndex> indexes = new LinkedHashMap<>();
+        try (ResultSet rs = metadata.getIndexInfo(connection.getCatalog(), sourceSchema, table, false, false)) {
+            while (rs.next()) {
+                if (rs.getShort("TYPE") == DatabaseMetaData.tableIndexStatistic) {
+                    continue;
+                }
+                String indexName = rs.getString("INDEX_NAME");
+                String columnName = rs.getString("COLUMN_NAME");
+                if (indexName == null || columnName == null) {
+                    continue;
+                }
+                MutableIndex index = indexes.get(indexName);
+                if (index == null) {
+                    index = new MutableIndex(
+                            indexName,
+                            !rsBoolean(rs, "NON_UNIQUE"),
+                            safeGetString(rs, "FILTER_CONDITION")
+                    );
+                    indexes.put(indexName, index);
+                }
+                index.columns.put(rs.getInt("ORDINAL_POSITION"),
+                        new IndexColumn(columnName, "D".equalsIgnoreCase(rs.getString("ASC_OR_DESC"))));
+            }
+        }
+
+        List<List<String>> constraintColumns = new ArrayList<>();
+        if (primaryKey != null) {
+            constraintColumns.add(primaryKey.columns());
+        }
+        uniqueConstraints.forEach(constraint -> constraintColumns.add(constraint.columns()));
+
+        List<IndexDefinition> result = new ArrayList<>();
+        for (MutableIndex index : indexes.values()) {
+            List<IndexColumn> indexColumns = orderedValues(index.columns);
+            List<String> names = indexColumns.stream().map(IndexColumn::name).toList();
+            if (index.unique && constraintColumns.stream().anyMatch(names::equals)) {
+                continue;
+            }
+            result.add(new IndexDefinition(index.name, index.unique, indexColumns, index.filterCondition));
+        }
+        result.sort(Comparator.comparing(IndexDefinition::name));
+        return result;
+    }
+
+    private List<ForeignKeyDefinition> fetchForeignKeys(
+            DatabaseMetaData metadata,
+            Connection connection,
+            String table
+    ) throws SQLException {
+        Map<String, MutableForeignKey> keys = new LinkedHashMap<>();
+        int unnamed = 0;
+        try (ResultSet rs = metadata.getImportedKeys(connection.getCatalog(), sourceSchema, table)) {
+            while (rs.next()) {
+                String name = rs.getString("FK_NAME");
+                if (name == null || name.isBlank()) {
+                    name = "FK_" + table + "_" + (++unnamed);
+                }
+                MutableForeignKey key = keys.get(name);
+                if (key == null) {
+                    key = new MutableForeignKey(
+                            name,
+                            rsString(rs, "PKTABLE_SCHEM"),
+                            rsString(rs, "PKTABLE_NAME"),
+                            rsShort(rs, "UPDATE_RULE"),
+                            rsShort(rs, "DELETE_RULE")
+                    );
+                    keys.put(name, key);
+                }
+                int position = rs.getInt("KEY_SEQ");
+                key.columns.put(position, rs.getString("FKCOLUMN_NAME"));
+                key.referencedColumns.put(position, rs.getString("PKCOLUMN_NAME"));
+            }
+        }
+        return keys.values().stream()
+                .map(key -> new ForeignKeyDefinition(
+                        key.name,
+                        orderedValues(key.columns),
+                        key.referencedSchema,
+                        key.referencedTable,
+                        orderedValues(key.referencedColumns),
+                        key.updateRule,
+                        key.deleteRule
+                ))
+                .toList();
+    }
+
+    private ViewDefinition loadViewDefinition(Connection connection, String view) throws SQLException {
+        String sql = "SELECT VIEW_DEFINITION FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
+        String definition;
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, sourceSchema);
+            ps.setString(2, view);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    throw new SQLException("View metadata not found: " + view);
+                }
+                definition = rs.getString(1);
+            }
+        }
+
+        List<String> columns = new ArrayList<>();
+        String columnSql = "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS " +
+                "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION";
+        try (PreparedStatement ps = connection.prepareStatement(columnSql)) {
+            ps.setString(1, sourceSchema);
+            ps.setString(2, view);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    columns.add(rs.getString(1));
+                }
+            }
+        }
+        return new ViewDefinition(view, columns, definition);
+    }
+
+    private void initializeTarget() {
+        target.execute("CREATE SCHEMA IF NOT EXISTS " + quoteIdentifier(targetSchema));
+        String table = qualifiedTarget(FAILURE_TABLE);
+        target.execute("CREATE TABLE IF NOT EXISTS " + table + " (" +
+                "\"ID\" BIGINT GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY," +
+                "\"OBJECT_TYPE\" VARCHAR(32) NOT NULL," +
+                "\"OBJECT_NAME\" VARCHAR(512) NOT NULL," +
+                "\"ATTEMPT_COUNT\" INTEGER NOT NULL," +
+                "\"LAST_ATTEMPT\" TIMESTAMP NOT NULL," +
+                "\"ERROR_MESSAGE\" TEXT," +
+                "UNIQUE (\"OBJECT_TYPE\", \"OBJECT_NAME\")" +
+                ")");
+    }
+
+    private void dropSourceViewsFromTarget(Set<String> views) {
+        for (String view : views) {
+            if (isBlacklisted(view)) {
+                continue;
+            }
+            try {
+                target.execute("DROP VIEW IF EXISTS " + qualifiedTarget(view) + " CASCADE");
+            } catch (RuntimeException ex) {
+                log.debug("Ignoring pre-refresh view drop failure for {}: {}", view, ex.getMessage());
+            }
+        }
+    }
+
+    private void syncSequence(SequenceDefinition sequence) {
+        String qualified = qualifiedTarget(sequence.name());
+        target.execute("DROP SEQUENCE IF EXISTS " + qualified + (h2TestTarget ? "" : " CASCADE"));
+        StringBuilder ddl = new StringBuilder("CREATE SEQUENCE ").append(qualified)
+                .append(" START WITH ").append(sequence.baseValue().toPlainString())
+                .append(" INCREMENT BY ").append(sequence.increment().toPlainString());
+        if (sequence.minimumValue() != null) {
+            ddl.append(" MINVALUE ").append(sequence.minimumValue().toPlainString());
+        }
+        if (sequence.maximumValue() != null) {
+            ddl.append(" MAXVALUE ").append(sequence.maximumValue().toPlainString());
+        }
+        ddl.append(sequence.cycle() ? " CYCLE" : " NO CYCLE");
+        if (sequence.cache() > 0) {
+            ddl.append(" CACHE ").append(sequence.cache());
+        }
+        target.execute(ddl.toString());
+        log.info("Synced PostgreSQL sequence {} nextValue={}", sequence.name(), sequence.baseValue());
+    }
+
+    private void copyTable(TableDefinition table) {
+        log.info("Copying H2 table {}.{} to PostgreSQL {}.{}",
+                sourceSchema, table.name(), targetSchema, table.name());
+        createTargetTable(table);
+        bulkInsert(table);
+        syncIdentityNextValues(table);
+    }
+
+    private void createTargetTable(TableDefinition table) {
+        String qualified = qualifiedTarget(table.name());
+        target.execute("DROP TABLE IF EXISTS " + qualified + " CASCADE");
+
+        List<String> parts = new ArrayList<>();
+        for (ColumnDefinition column : table.columns()) {
+            StringBuilder definition = new StringBuilder(quoteIdentifier(column.name()))
+                    .append(' ')
+                    .append(mapType(column));
+            if (column.generated()) {
+                if (column.generationExpression() == null || column.generationExpression().isBlank()) {
+                    throw new IllegalStateException("Generated column expression is unavailable for " +
+                            table.name() + "." + column.name());
+                }
+                definition.append(" GENERATED ALWAYS AS (")
+                        .append(viewSqlTranslator.translate(column.generationExpression()))
+                        .append(')');
+                if (!h2TestTarget) {
+                    definition.append(" STORED");
+                }
+            } else if (column.autoIncrement()) {
+                definition.append(" GENERATED BY DEFAULT AS IDENTITY")
+                        .append(identityOptions(column));
+            } else {
+                String translatedDefault = translateDefault(column.defaultValue());
+                if (translatedDefault != null) {
+                    definition.append(" DEFAULT ").append(translatedDefault);
+                }
+            }
+            if (!column.nullable() || isPrimaryKeyColumn(table, column.name())) {
+                definition.append(" NOT NULL");
+            }
+            parts.add(definition.toString());
+        }
+
+        target.execute("CREATE TABLE " + qualified + " (" + String.join(", ", parts) + ")");
+    }
+
+    private void syncPrimaryKey(TableDefinition table, ConstraintDefinition primaryKey) {
+        dropTargetConstraint(table.name(), primaryKey.name());
+        target.execute("ALTER TABLE " + qualifiedTarget(table.name()) +
+                " ADD CONSTRAINT " + quoteIdentifier(primaryKey.name()) +
+                " PRIMARY KEY (" + quoteIdentifiers(primaryKey.columns()) + ")");
+        log.info("Created PostgreSQL primary key {} on {}", primaryKey.name(), table.name());
+    }
+
+    private void syncUniqueConstraint(TableDefinition table, ConstraintDefinition unique) {
+        dropTargetConstraint(table.name(), unique.name());
+        target.execute("ALTER TABLE " + qualifiedTarget(table.name()) +
+                " ADD CONSTRAINT " + quoteIdentifier(unique.name()) +
+                " UNIQUE (" + quoteIdentifiers(unique.columns()) + ")");
+        log.info("Created PostgreSQL unique constraint {} on {}", unique.name(), table.name());
+    }
+
+    private void dropTargetConstraint(String table, String constraint) {
+        target.execute("ALTER TABLE " + qualifiedTarget(table) +
+                " DROP CONSTRAINT IF EXISTS " + quoteIdentifier(constraint));
+    }
+
+    private boolean isPrimaryKeyColumn(TableDefinition table, String column) {
+        return table.primaryKey() != null && table.primaryKey().columns().contains(column);
+    }
+
+    private String identityOptions(ColumnDefinition column) {
+        List<String> options = new ArrayList<>();
+        if (column.identityStart() != null) {
+            options.add("START WITH " + column.identityStart().toPlainString());
+        }
+        if (column.identityIncrement() != null) {
+            options.add("INCREMENT BY " + column.identityIncrement().toPlainString());
+        }
+        if (column.identityMinimum() != null) {
+            options.add("MINVALUE " + column.identityMinimum().toPlainString());
+        }
+        if (column.identityMaximum() != null) {
+            options.add("MAXVALUE " + column.identityMaximum().toPlainString());
+        }
+        options.add(column.identityCycle() ? "CYCLE" : "NO CYCLE");
+        if (column.identityCache() > 0) {
+            options.add("CACHE " + column.identityCache());
+        }
+        return options.isEmpty() ? "" : " (" + String.join(" ", options) + ")";
+    }
+
+    private void syncIdentityNextValues(TableDefinition table) {
+        for (ColumnDefinition column : table.columns()) {
+            if (!column.autoIncrement() || column.identityBase() == null) {
+                continue;
+            }
+            if (h2TestTarget) {
+                target.execute("ALTER TABLE " + qualifiedTarget(table.name()) +
+                        " ALTER COLUMN " + quoteIdentifier(column.name()) +
+                        " RESTART WITH " + column.identityBase().toPlainString());
+            } else {
+                String tableRegclass = quoteIdentifier(targetSchema) + "." + quoteIdentifier(table.name());
+                target.queryForObject(
+                        "SELECT setval(pg_get_serial_sequence(?, ?), CAST(? AS BIGINT), false)",
+                        Long.class,
+                        tableRegclass,
+                        column.name(),
+                        column.identityBase().longValueExact()
+                );
+            }
+            log.info("Aligned identity {}.{} nextValue={}",
+                    table.name(), column.name(), column.identityBase());
+        }
+    }
+
+    private String translateDefault(String defaultValue) {
+        if (defaultValue == null || defaultValue.isBlank() || "NULL".equalsIgnoreCase(defaultValue.trim())) {
+            return null;
+        }
+        String trimmed = defaultValue.trim();
+        Matcher sequenceMatcher = NEXT_VALUE_PATTERN.matcher(trimmed);
+        if (sequenceMatcher.matches()) {
+            String sequenceName = firstNonNull(sequenceMatcher.group(3), sequenceMatcher.group(4));
+            String regclass = quoteIdentifier(targetSchema) + "." + quoteIdentifier(sequenceName);
+            return "nextval('" + regclass.replace("'", "''") + "'::regclass)";
+        }
+        return viewSqlTranslator.translate(trimmed);
+    }
+
+    private String mapType(ColumnDefinition column) {
+        int jdbcType = column.jdbcType();
+        String typeName = column.typeName() == null ? "" : column.typeName().toUpperCase(Locale.ROOT);
+        int precision = column.size();
+        int scale = column.scale();
+
+        if (typeName.contains("UUID")) return "UUID";
+        if (typeName.contains("JSON")) return "JSONB";
+        if (typeName.contains("INTERVAL")) return "INTERVAL";
+        if (jdbcType == Types.ARRAY || typeName.endsWith(" ARRAY")) {
+            return mapArrayType(typeName);
+        }
+
+        return switch (jdbcType) {
+            case Types.TINYINT, Types.SMALLINT -> "SMALLINT";
+            case Types.INTEGER -> "INTEGER";
+            case Types.BIGINT -> "BIGINT";
+            case Types.NUMERIC, Types.DECIMAL -> {
+                if (precision <= 0 || precision > 1000 || scale < 0 || scale > precision) {
+                    yield "NUMERIC";
+                }
+                yield "NUMERIC(" + precision + "," + scale + ")";
+            }
+            case Types.REAL -> "REAL";
+            case Types.FLOAT, Types.DOUBLE -> "DOUBLE PRECISION";
+            case Types.BOOLEAN, Types.BIT -> "BOOLEAN";
+            case Types.DATE -> "DATE";
+            case Types.TIME -> "TIME";
+            case Types.TIME_WITH_TIMEZONE -> "TIME WITH TIME ZONE";
+            case Types.TIMESTAMP -> "TIMESTAMP";
+            case Types.TIMESTAMP_WITH_TIMEZONE -> "TIMESTAMP WITH TIME ZONE";
+            case Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY, Types.BLOB -> "BYTEA";
+            case Types.CLOB, Types.NCLOB, Types.LONGVARCHAR, Types.LONGNVARCHAR -> "TEXT";
+            case Types.CHAR, Types.NCHAR -> precision > 0 && precision <= POSTGRESQL_MAX_VARCHAR_LENGTH
+                    ? "CHAR(" + precision + ")" : "TEXT";
+            case Types.VARCHAR, Types.NVARCHAR -> precision > 0 && precision <= POSTGRESQL_MAX_VARCHAR_LENGTH
+                    ? "VARCHAR(" + precision + ")" : "TEXT";
+            default -> "TEXT";
+        };
+    }
+
+    private String mapArrayType(String h2TypeName) {
+        String base = h2TypeName.replaceFirst("(?i)\\s+ARRAY$", "").trim();
+        if (base.contains("BIGINT")) return "BIGINT[]";
+        if (base.contains("SMALLINT") || base.contains("TINYINT")) return "SMALLINT[]";
+        if (base.contains("INTEGER")) return "INTEGER[]";
+        if (base.contains("DOUBLE") || base.contains("FLOAT")) return "DOUBLE PRECISION[]";
+        if (base.contains("REAL")) return "REAL[]";
+        if (base.contains("NUMERIC") || base.contains("DECIMAL")) return "NUMERIC[]";
+        if (base.contains("BOOLEAN")) return "BOOLEAN[]";
+        if (base.contains("UUID")) return "UUID[]";
+        if (base.contains("TIMESTAMP")) return "TIMESTAMP[]";
+        if (base.equals("DATE")) return "DATE[]";
+        return "TEXT[]";
+    }
+
+    private void bulkInsert(TableDefinition table) {
+        List<ColumnDefinition> insertable = table.columns().stream()
+                .filter(column -> !column.generated())
+                .toList();
+        boolean hasLob = insertable.stream().anyMatch(this::isLobColumn);
+        String sourceTable = qualifiedSource(table.name());
+        String targetTable = qualifiedTarget(table.name());
+
+        if (insertable.isEmpty()) {
+            long count = source.queryForObject("SELECT COUNT(*) FROM " + sourceTable, Long.class);
+            for (long i = 0; i < count; i++) {
+                target.execute("INSERT INTO " + targetTable + " DEFAULT VALUES");
+            }
+            log.info("Inserted {} rows into {}", count, targetTable);
+            return;
+        }
+
+        String columns = insertable.stream().map(ColumnDefinition::name)
+                .map(this::quoteIdentifier).collect(Collectors.joining(","));
+        String selectSql = "SELECT " + columns + " FROM " + sourceTable;
+        String placeholders = insertable.stream().map(ignored -> "?").collect(Collectors.joining(","));
+        String insertSql = "INSERT INTO " + targetTable + " (" + columns + ") VALUES (" + placeholders + ")";
+
+        long total = 0;
+        try {
+            Long count = source.queryForObject("SELECT COUNT(*) FROM " + sourceTable, Long.class);
+            total = count == null ? 0 : count;
+        } catch (RuntimeException ex) {
+            log.warn("Count failed (non-fatal) for {}: {}", sourceTable, ex.getMessage());
+        }
+
+        try (Connection sourceConnection = sourceDataSource.getConnection();
+             PreparedStatement select = sourceConnection.prepareStatement(
+                     selectSql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+             Connection targetConnection = targetDataSource.getConnection()) {
+            select.setFetchSize(Math.max(batchSize, 100));
+            targetConnection.setAutoCommit(false);
+            try (ResultSet rs = select.executeQuery();
+                 PreparedStatement insert = targetConnection.prepareStatement(insertSql)) {
+                long copied = 0;
+                while (rs.next()) {
+                    List<Object> values = new ArrayList<>(insertable.size());
+                    List<AutoCloseable> rowResources = new ArrayList<>();
+                    try {
+                        for (int i = 0; i < insertable.size(); i++) {
+                            values.add(readH2Value(rs, i + 1, insertable.get(i)));
+                        }
+                        for (int i = 0; i < insertable.size(); i++) {
+                            bindTargetValue(
+                                    targetConnection,
+                                    insert,
+                                    i + 1,
+                                    values.get(i),
+                                    insertable.get(i),
+                                    rowResources
+                            );
+                        }
+                        if (hasLob) {
+                            // Execute immediately so streams are consumed before the H2 cursor advances.
+                            insert.executeUpdate();
+                            insert.clearParameters();
+                        } else {
+                            insert.addBatch();
+                        }
+                        copied++;
+                        if (copied % batchSize == 0) {
+                            if (!hasLob) {
+                                insert.executeBatch();
+                            }
+                            targetConnection.commit();
+                            log.info("Inserted {} / {} rows into {}", copied, total, targetTable);
+                        }
+                    } finally {
+                        closeResources(rowResources);
+                        freeLobValues(values);
+                    }
+                }
+                if (!hasLob) {
+                    insert.executeBatch();
+                }
+                targetConnection.commit();
+                log.info("Inserted {} rows into {}", copied, targetTable);
+            } catch (SQLException ex) {
+                targetConnection.rollback();
+                throw ex;
+            } finally {
+                targetConnection.setAutoCommit(true);
+            }
+        } catch (SQLException ex) {
+            throw new RuntimeException("Bulk insert failed for target " + targetTable, ex);
+        }
+    }
+
+    private Object readH2Value(ResultSet rs, int index, ColumnDefinition column) throws SQLException {
+        return switch (column.jdbcType()) {
+            case Types.BLOB -> rs.getBlob(index);
+            case Types.CLOB, Types.NCLOB -> rs.getClob(index);
+            case Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY -> rs.getBytes(index);
+            case Types.LONGVARCHAR, Types.LONGNVARCHAR -> rs.getString(index);
+            case Types.ARRAY -> readSqlArray(rs.getArray(index));
+            default -> normalizeJdbcValue(rs.getObject(index), column);
+        };
+    }
+
+    private Object normalizeJdbcValue(Object value, ColumnDefinition column) throws SQLException {
+        if (value instanceof Blob blob) {
+            try {
+                return blob.getBytes(1, Math.toIntExact(blob.length()));
+            } finally {
+                blob.free();
+            }
+        }
+        if (value instanceof Clob clob) {
+            try {
+                return clob.getSubString(1, Math.toIntExact(clob.length()));
+            } finally {
+                clob.free();
+            }
+        }
+        if (value instanceof java.sql.Array array) {
+            return readSqlArray(array);
+        }
+        if (value instanceof byte[] bytes && column.typeName() != null
+                && column.typeName().toUpperCase(Locale.ROOT).contains("JSON")) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return value;
+    }
+
+    private Object[] readSqlArray(java.sql.Array array) throws SQLException {
+        if (array == null) return null;
+        try {
+            Object value = array.getArray();
+            if (value instanceof Object[] objects) {
+                return objects;
+            }
+            int length = Array.getLength(value);
+            Object[] objects = new Object[length];
+            for (int i = 0; i < length; i++) {
+                objects[i] = Array.get(value, i);
+            }
+            return objects;
+        } finally {
+            array.free();
+        }
+    }
+
+    private void bindTargetValue(
+            Connection targetConnection,
+            PreparedStatement statement,
+            int index,
+            Object value,
+            ColumnDefinition column,
+            List<AutoCloseable> resources
+    ) throws SQLException {
+        if (value == null) {
+            statement.setObject(index, null);
+            return;
+        }
+        if (value instanceof Blob blob) {
+            InputStream stream = blob.getBinaryStream();
+            statement.setBinaryStream(index, stream, blob.length());
+            resources.add(stream);
+            return;
+        }
+        if (value instanceof Clob clob) {
+            Reader reader = clob.getCharacterStream();
+            statement.setCharacterStream(index, reader, clob.length());
+            resources.add(reader);
+            return;
+        }
+        if (column.jdbcType() == Types.ARRAY && value instanceof Object[] values) {
+            statement.setArray(index, targetConnection.createArrayOf(postgresqlArrayElementType(column), values));
+            return;
+        }
+        if (!h2TestTarget && column.typeName() != null
+                && column.typeName().toUpperCase(Locale.ROOT).contains("JSON")) {
+            statement.setObject(index, value.toString(), Types.OTHER);
+            return;
+        }
+        statement.setObject(index, value);
+    }
+
+    private boolean isLobColumn(ColumnDefinition column) {
+        return column.jdbcType() == Types.BLOB
+                || column.jdbcType() == Types.CLOB
+                || column.jdbcType() == Types.NCLOB;
+    }
+
+    private void closeResources(List<AutoCloseable> resources) {
+        for (int i = resources.size() - 1; i >= 0; i--) {
+            try {
+                resources.get(i).close();
+            } catch (Exception ex) {
+                log.debug("Failed to close streamed LOB resource: {}", ex.getMessage());
+            }
+        }
+    }
+
+    private void freeLobValues(List<Object> values) {
+        for (Object value : values) {
+            try {
+                if (value instanceof Blob blob) {
+                    blob.free();
+                } else if (value instanceof Clob clob) {
+                    clob.free();
+                }
+            } catch (SQLException ex) {
+                log.debug("Failed to free H2 LOB value: {}", ex.getMessage());
+            }
+        }
+    }
+
+    private String postgresqlArrayElementType(ColumnDefinition column) {
+        String mapped = mapArrayType(column.typeName() == null ? "" : column.typeName());
+        return mapped.substring(0, mapped.length() - 2);
+    }
+
+    private void syncIndex(TableDefinition table, IndexDefinition index) {
+        String qualifiedIndex = quoteIdentifier(targetSchema) + "." + quoteIdentifier(index.name());
+        target.execute("DROP INDEX IF EXISTS " + qualifiedIndex);
+        String columns = index.columns().stream()
+                .map(column -> quoteIdentifier(column.name()) + (column.descending() ? " DESC" : " ASC"))
+                .collect(Collectors.joining(", "));
+        StringBuilder ddl = new StringBuilder("CREATE ");
+        if (index.unique()) {
+            ddl.append("UNIQUE ");
+        }
+        ddl.append("INDEX ").append(qualifiedIndex)
+                .append(" ON ").append(qualifiedTarget(table.name()))
+                .append(" (").append(columns).append(')');
+        if (index.filterCondition() != null && !index.filterCondition().isBlank()) {
+            ddl.append(" WHERE ").append(viewSqlTranslator.translate(index.filterCondition()));
+        }
+        target.execute(ddl.toString());
+        log.info("Created PostgreSQL index {} on {}", index.name(), table.name());
+    }
+
+    private void syncForeignKey(TableDefinition table, ForeignKeyDefinition foreignKey) {
+        dropTargetConstraint(table.name(), foreignKey.name());
+        String ddl = "ALTER TABLE " + qualifiedTarget(table.name()) +
+                " ADD CONSTRAINT " + quoteIdentifier(foreignKey.name()) +
+                " FOREIGN KEY (" + quoteIdentifiers(foreignKey.columns()) + ")" +
+                " REFERENCES " + qualifiedTarget(foreignKey.referencedTable()) +
+                " (" + quoteIdentifiers(foreignKey.referencedColumns()) + ")" +
+                ruleSql("UPDATE", foreignKey.updateRule()) +
+                ruleSql("DELETE", foreignKey.deleteRule());
+        target.execute(ddl);
+        log.info("Created PostgreSQL foreign key {} on {}", foreignKey.name(), table.name());
+    }
+
+    private String ruleSql(String operation, short rule) {
+        String action = switch (rule) {
+            case DatabaseMetaData.importedKeyCascade -> "CASCADE";
+            case DatabaseMetaData.importedKeySetNull -> "SET NULL";
+            case DatabaseMetaData.importedKeySetDefault -> "SET DEFAULT";
+            case DatabaseMetaData.importedKeyRestrict -> "RESTRICT";
+            default -> "NO ACTION";
+        };
+        return " ON " + operation + " " + action;
+    }
+
+    private void syncViewsWithDependencyAwareness(
+            Map<String, ViewDefinition> views,
+            List<MigrationFailure> failures
+    ) {
+        Deque<ViewDefinition> queue = new ArrayDeque<>(views.values());
+        Map<String, Integer> attempts = new HashMap<>();
+        int deferralLimit = Math.max(3, maxRetries) * 4;
+
+        while (!queue.isEmpty()) {
+            ViewDefinition view = queue.removeFirst();
+            int attempt = attempts.merge(view.name(), 1, Integer::sum);
+            try {
+                syncView(view);
+                recordSuccess("VIEW", view.name());
+            } catch (RuntimeException ex) {
+                if (isMissingDependency(ex) && attempt <= deferralLimit) {
+                    log.info("Deferring PostgreSQL view {} until dependencies exist (attempt {}). Cause: {}",
+                            view.name(), attempt, truncate(extractMessage(ex), 512));
+                    queue.addLast(view);
+                } else {
+                    recordTerminalFailure("VIEW", view.name(), attempt, ex, failures);
+                    log.warn("Giving up on PostgreSQL view {} after {} attempts: {}",
+                            view.name(), attempt, ex.toString());
+                }
+            }
+        }
+    }
+
+    private void syncView(ViewDefinition view) {
+        String qualified = qualifiedTarget(view.name());
+        target.execute("DROP VIEW IF EXISTS " + qualified + " CASCADE");
+        String columnList = view.columns().isEmpty() ? "" :
+                view.columns().stream().map(this::quoteIdentifier)
+                        .collect(Collectors.joining(", ", " (", ")"));
+        target.execute("CREATE VIEW " + qualified + columnList + " AS " +
+                viewSqlTranslator.translate(view.sql()));
+        log.info("Created PostgreSQL view {}", view.name());
+    }
+
+    private boolean isMissingDependency(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof SQLException sqlException) {
+                String state = sqlException.getSQLState();
+                if ("42P01".equals(state) || "3F000".equals(state) || "42S02".equals(state)) {
+                    return true;
+                }
+                String message = sqlException.getMessage();
+                if (message != null && message.toLowerCase(Locale.ROOT).contains("not found")) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private boolean retry(
+            Runnable task,
+            String type,
+            String name,
+            List<MigrationFailure> failures
+    ) {
+        int attempt = 0;
+        while (true) {
+            try {
+                attempt++;
+                task.run();
+                recordSuccess(type, name);
+                return true;
+            } catch (Exception ex) {
+                log.warn("Failed to process PostgreSQL {} {} on attempt {}: {}",
+                        type, name, attempt, ex.toString());
+                if (attempt >= maxRetries) {
+                    recordTerminalFailure(type, name, attempt, ex, failures);
+                    return false;
+                }
+                try {
+                    Thread.sleep(1000L * attempt * attempt);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    recordTerminalFailure(type, name, attempt, interrupted, failures);
+                    return false;
+                }
+            }
+        }
+    }
+
+    private void waitForFutures(
+            List<Future<?>> futures,
+            String objectType,
+            List<MigrationFailure> failures
+    ) {
+        try {
+            for (Future<?> future : futures) {
+                try {
+                    future.get();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while waiting for PostgreSQL " + objectType + " tasks", ex);
+                } catch (ExecutionException ex) {
+                    Throwable cause = ex.getCause() == null ? ex : ex.getCause();
+                    log.error("Unexpected failure while processing PostgreSQL {} tasks", objectType, cause);
+                    failures.add(new MigrationFailure(
+                            "INTERNAL_" + objectType.toUpperCase(Locale.ROOT),
+                            objectType,
+                            extractMessage(cause)
+                    ));
+                }
+            }
+        } finally {
+            futures.clear();
+        }
+    }
+
+    private void recordTerminalFailure(
+            String type,
+            String name,
+            int attempt,
+            Exception ex,
+            List<MigrationFailure> failures
+    ) {
+        try {
+            recordFailure(type, name, attempt, ex);
+        } catch (RuntimeException logFailure) {
+            ex.addSuppressed(logFailure);
+            log.error("Failed to record terminal migration failure for {} {}", type, name, logFailure);
+        }
+        failures.add(new MigrationFailure(type, name, extractMessage(ex)));
+    }
+
+    private void recordSuccess(String type, String name) {
+        if (h2TestTarget) {
+            target.update("MERGE INTO " + qualifiedTarget(FAILURE_TABLE) +
+                            " (\"OBJECT_TYPE\", \"OBJECT_NAME\", \"ATTEMPT_COUNT\", \"LAST_ATTEMPT\", \"ERROR_MESSAGE\") " +
+                            "KEY (\"OBJECT_TYPE\", \"OBJECT_NAME\") VALUES (?, ?, 0, CURRENT_TIMESTAMP, NULL)",
+                    type, name);
+            return;
+        }
+        target.update("INSERT INTO " + qualifiedTarget(FAILURE_TABLE) +
+                        " (\"OBJECT_TYPE\", \"OBJECT_NAME\", \"ATTEMPT_COUNT\", \"LAST_ATTEMPT\", \"ERROR_MESSAGE\") " +
+                        "VALUES (?, ?, 0, CURRENT_TIMESTAMP, NULL) " +
+                        "ON CONFLICT (\"OBJECT_TYPE\", \"OBJECT_NAME\") DO UPDATE SET " +
+                        "\"ATTEMPT_COUNT\" = 0, \"LAST_ATTEMPT\" = EXCLUDED.\"LAST_ATTEMPT\", \"ERROR_MESSAGE\" = NULL",
+                type, name);
+    }
+
+    private void recordFailure(String type, String name, int attempt, Exception ex) {
+        String error = truncate(exceptionToString(ex), 16_000);
+        if (h2TestTarget) {
+            target.update("MERGE INTO " + qualifiedTarget(FAILURE_TABLE) +
+                            " (\"OBJECT_TYPE\", \"OBJECT_NAME\", \"ATTEMPT_COUNT\", \"LAST_ATTEMPT\", \"ERROR_MESSAGE\") " +
+                            "KEY (\"OBJECT_TYPE\", \"OBJECT_NAME\") VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?)",
+                    type, name, attempt, error);
+            return;
+        }
+        target.update("INSERT INTO " + qualifiedTarget(FAILURE_TABLE) +
+                        " (\"OBJECT_TYPE\", \"OBJECT_NAME\", \"ATTEMPT_COUNT\", \"LAST_ATTEMPT\", \"ERROR_MESSAGE\") " +
+                        "VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?) " +
+                        "ON CONFLICT (\"OBJECT_TYPE\", \"OBJECT_NAME\") DO UPDATE SET " +
+                        "\"ATTEMPT_COUNT\" = EXCLUDED.\"ATTEMPT_COUNT\", " +
+                        "\"LAST_ATTEMPT\" = EXCLUDED.\"LAST_ATTEMPT\", " +
+                        "\"ERROR_MESSAGE\" = EXCLUDED.\"ERROR_MESSAGE\"",
+                type, name, attempt, error);
+    }
+
+    private boolean isBlacklisted(String name) {
+        if (name == null) return false;
+        String normalized = name.toUpperCase(Locale.ROOT);
+        return blacklist.contains(normalized)
+                || blacklist.contains(sourceSchema.toUpperCase(Locale.ROOT) + "." + normalized);
+    }
+
+    private boolean isSourceSchema(String schema) {
+        return schema == null || schema.isBlank() || sourceSchema.equalsIgnoreCase(schema);
+    }
+
+    private String qualifiedSource(String object) {
+        return quoteIdentifier(sourceSchema) + "." + quoteIdentifier(object);
+    }
+
+    private String qualifiedTarget(String object) {
+        return quoteIdentifier(targetSchema) + "." + quoteIdentifier(object);
+    }
+
+    private String quoteIdentifiers(List<String> identifiers) {
+        return identifiers.stream().map(this::quoteIdentifier).collect(Collectors.joining(", "));
+    }
+
+    private String quoteIdentifier(String identifier) {
+        return "\"" + requireIdentifier(identifier, "identifier").replace("\"", "\"\"") + "\"";
+    }
+
+    private static String requireIdentifier(String identifier, String label) {
+        if (identifier == null || identifier.isBlank()) {
+            throw new IllegalArgumentException(label + " must not be blank");
+        }
+        return identifier.trim();
+    }
+
+    private static Set<String> parseBlacklist(String csv) {
+        return Arrays.stream((csv == null ? "" : csv).split(","))
+                .map(String::trim)
+                .map(value -> value.replaceAll("^[\\\"']|[\\\"']$", ""))
+                .filter(value -> !value.isBlank())
+                .map(value -> value.toUpperCase(Locale.ROOT))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static boolean detectH2Target(DataSource dataSource) {
+        if (dataSource instanceof DriverManagerDataSource driverManagerDataSource) {
+            String url = driverManagerDataSource.getUrl();
+            return url != null && url.toLowerCase(Locale.ROOT).startsWith("jdbc:h2:");
+        }
+        // Do not connect to a disabled/placeholder PostgreSQL destination at
+        // application startup. Production behavior is the PostgreSQL branch.
+        return false;
+    }
+
+    private static String safeGetString(ResultSet rs, String column) {
+        try {
+            return rs.getString(column);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static boolean rsBoolean(ResultSet rs, String column) {
+        try {
+            return rs.getBoolean(column);
+        } catch (SQLException ex) {
+            return false;
+        }
+    }
+
+    private static String rsString(ResultSet rs, String column) {
+        try {
+            return rs.getString(column);
+        } catch (SQLException ex) {
+            return null;
+        }
+    }
+
+    private static short rsShort(ResultSet rs, String column) {
+        try {
+            return rs.getShort(column);
+        } catch (SQLException ex) {
+            return DatabaseMetaData.importedKeyNoAction;
+        }
+    }
+
+    private static <T> List<T> orderedValues(Map<Integer, T> values) {
+        return values.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(Map.Entry::getValue)
+                .toList();
+    }
+
+    private static String firstNonNull(String first, String second) {
+        return first != null ? first : second;
+    }
+
+    private static String extractMessage(Throwable ex) {
+        if (ex == null) return "";
+        if (ex.getMessage() != null && !ex.getMessage().isBlank()) return ex.getMessage();
+        return ex.getCause() == null ? ex.toString() : extractMessage(ex.getCause());
+    }
+
+    private static String exceptionToString(Exception ex) {
+        StringBuilder out = new StringBuilder(ex.toString()).append('\n');
+        for (StackTraceElement element : ex.getStackTrace()) {
+            out.append("  at ").append(element).append('\n');
+        }
+        return out.toString();
+    }
+
+    private static String truncate(String value, int max) {
+        return value == null || value.length() <= max ? value : value.substring(0, max);
+    }
+
+    public static final class MigrationIncompleteException extends RuntimeException {
+        private final int failureCount;
+
+        private MigrationIncompleteException(List<MigrationFailure> failures) {
+            super("H2 -> PostgreSQL migration completed with " + failures.size() +
+                    " failed objects: " + failures.stream()
+                    .map(failure -> failure.type() + " " + failure.name())
+                    .limit(10)
+                    .collect(Collectors.joining(", ")));
+            this.failureCount = failures.size();
+        }
+
+        public int getFailureCount() {
+            return failureCount;
+        }
+    }
+
+    record MigrationFailure(String type, String name, String message) {
+    }
+
+    record MigrationSnapshot(
+            Set<String> tableNames,
+            Set<String> viewNames,
+            Map<String, TableDefinition> tables,
+            Map<String, ViewDefinition> views,
+            List<SequenceDefinition> sequences
+    ) {
+    }
+
+    record TableDefinition(
+            String name,
+            List<ColumnDefinition> columns,
+            ConstraintDefinition primaryKey,
+            List<ConstraintDefinition> uniqueConstraints,
+            List<IndexDefinition> indexes,
+            List<ForeignKeyDefinition> foreignKeys
+    ) {
+    }
+
+    record ColumnDefinition(
+            String name,
+            int jdbcType,
+            String typeName,
+            int size,
+            int scale,
+            boolean nullable,
+            boolean autoIncrement,
+            boolean generated,
+            String defaultValue,
+            String generationExpression,
+            BigDecimal identityStart,
+            BigDecimal identityIncrement,
+            BigDecimal identityMinimum,
+            BigDecimal identityMaximum,
+            BigDecimal identityBase,
+            boolean identityCycle,
+            long identityCache
+    ) {
+    }
+
+    private record ColumnExtras(
+            String generationExpression,
+            BigDecimal identityStart,
+            BigDecimal identityIncrement,
+            BigDecimal identityMinimum,
+            BigDecimal identityMaximum,
+            BigDecimal identityBase,
+            boolean identityCycle,
+            long identityCache
+    ) {
+        private static final ColumnExtras EMPTY = new ColumnExtras(
+                null, null, null, null, null, null, false, 0
+        );
+    }
+
+    record ConstraintDefinition(String name, List<String> columns) {
+    }
+
+    record IndexColumn(String name, boolean descending) {
+    }
+
+    record IndexDefinition(
+            String name,
+            boolean unique,
+            List<IndexColumn> columns,
+            String filterCondition
+    ) {
+    }
+
+    record ForeignKeyDefinition(
+            String name,
+            List<String> columns,
+            String referencedSchema,
+            String referencedTable,
+            List<String> referencedColumns,
+            short updateRule,
+            short deleteRule
+    ) {
+    }
+
+    record ViewDefinition(String name, List<String> columns, String sql) {
+    }
+
+    record SequenceDefinition(
+            String name,
+            BigDecimal increment,
+            BigDecimal baseValue,
+            BigDecimal minimumValue,
+            BigDecimal maximumValue,
+            boolean cycle,
+            long cache
+    ) {
+    }
+
+    private static final class MutableIndex {
+        private final String name;
+        private final boolean unique;
+        private final Map<Integer, IndexColumn> columns = new LinkedHashMap<>();
+        private final String filterCondition;
+
+        private MutableIndex(String name, boolean unique, String filterCondition) {
+            this.name = name;
+            this.unique = unique;
+            this.filterCondition = filterCondition;
+        }
+    }
+
+    private static final class MutableForeignKey {
+        private final String name;
+        private final String referencedSchema;
+        private final String referencedTable;
+        private final short updateRule;
+        private final short deleteRule;
+        private final Map<Integer, String> columns = new LinkedHashMap<>();
+        private final Map<Integer, String> referencedColumns = new LinkedHashMap<>();
+
+        private MutableForeignKey(
+                String name,
+                String referencedSchema,
+                String referencedTable,
+                short updateRule,
+                short deleteRule
+        ) {
+            this.name = name;
+            this.referencedSchema = referencedSchema;
+            this.referencedTable = referencedTable;
+            this.updateRule = updateRule;
+            this.deleteRule = deleteRule;
+        }
+    }
+}

--- a/src/main/java/com/example/h2sync/service/H2ToPostgresqlMigrationReportPrinter.java
+++ b/src/main/java/com/example/h2sync/service/H2ToPostgresqlMigrationReportPrinter.java
@@ -1,0 +1,337 @@
+package com.example.h2sync.service;
+
+import org.slf4j.Logger;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static com.example.h2sync.service.H2ToPostgresqlLoaderService.ForeignKeyDefinition;
+import static com.example.h2sync.service.H2ToPostgresqlLoaderService.IndexDefinition;
+import static com.example.h2sync.service.H2ToPostgresqlLoaderService.MigrationSnapshot;
+import static com.example.h2sync.service.H2ToPostgresqlLoaderService.SequenceDefinition;
+import static com.example.h2sync.service.H2ToPostgresqlLoaderService.TableDefinition;
+
+/** Builds the post-load comparison report printed after every full refresh. */
+final class H2ToPostgresqlMigrationReportPrinter {
+
+    private final Logger log;
+    private final JdbcTemplate source;
+    private final JdbcTemplate target;
+    private final DataSource targetDataSource;
+    private final String sourceSchema;
+    private final String targetSchema;
+    private final Predicate<String> blacklist;
+    private final boolean h2TestTarget;
+
+    H2ToPostgresqlMigrationReportPrinter(
+            Logger log,
+            JdbcTemplate source,
+            JdbcTemplate target,
+            DataSource targetDataSource,
+            String sourceSchema,
+            String targetSchema,
+            Predicate<String> blacklist,
+            boolean h2TestTarget
+    ) {
+        this.log = log;
+        this.source = source;
+        this.target = target;
+        this.targetDataSource = targetDataSource;
+        this.sourceSchema = sourceSchema;
+        this.targetSchema = targetSchema;
+        this.blacklist = blacklist;
+        this.h2TestTarget = h2TestTarget;
+    }
+
+    void printReport(MigrationSnapshot snapshot) {
+        List<String[]> tableRows = new ArrayList<>();
+        for (String table : snapshot.tableNames()) {
+            tableRows.add(buildTableRow(table));
+        }
+
+        List<String[]> viewRows = new ArrayList<>();
+        for (String view : snapshot.viewNames()) {
+            viewRows.add(new String[]{view, objectStatus(view, "VIEW", view)});
+        }
+
+        List<String[]> sequenceRows = snapshot.sequences().stream()
+                .sorted(Comparator.comparing(SequenceDefinition::name))
+                .map(this::buildSequenceRow)
+                .toList();
+
+        List<String[]> indexRows = new ArrayList<>();
+        List<String[]> constraintRows = new ArrayList<>();
+        List<String[]> foreignKeyRows = new ArrayList<>();
+        for (TableDefinition table : snapshot.tables().values()) {
+            if (table.primaryKey() != null) {
+                constraintRows.add(new String[]{table.name(), "PRIMARY KEY", table.primaryKey().name(),
+                        constraintStatus(table.name(), table.primaryKey().name())});
+            }
+            for (var unique : table.uniqueConstraints()) {
+                constraintRows.add(new String[]{table.name(), "UNIQUE", unique.name(),
+                        constraintStatus(table.name(), unique.name())});
+            }
+            for (IndexDefinition index : table.indexes()) {
+                indexRows.add(new String[]{table.name(), index.name(),
+                        objectStatus(index.name(), "INDEX", table.name())});
+            }
+            for (ForeignKeyDefinition key : table.foreignKeys()) {
+                String status;
+                if ((key.referencedSchema() != null && !sourceSchema.equalsIgnoreCase(key.referencedSchema()))
+                        || blacklist.test(key.referencedTable())
+                        || !snapshot.tables().containsKey(key.referencedTable())) {
+                    status = "SKIPPED";
+                } else {
+                    status = objectStatus(key.name(), "FOREIGN_KEY", table.name());
+                }
+                foreignKeyRows.add(new String[]{table.name(), key.name(), status});
+            }
+        }
+
+        StringBuilder report = new StringBuilder();
+        report.append("================ H2 -> POSTGRESQL MIGRATION REPORT ================\n\n");
+        report.append(renderSection("Tables",
+                new String[]{"Table", "H2 Rows", "PostgreSQL Rows", "Status"}, tableRows)).append('\n');
+        report.append(renderSection("Views", new String[]{"View", "Status"}, viewRows)).append('\n');
+        report.append(renderSection("Sequences",
+                new String[]{"Sequence", "H2 Next", "PostgreSQL Next", "Status"}, sequenceRows)).append('\n');
+        report.append(renderSection("Constraints",
+                new String[]{"Table", "Type", "Constraint", "Status"}, constraintRows)).append('\n');
+        report.append(renderSection("Indexes", new String[]{"Table", "Index", "Status"}, indexRows)).append('\n');
+        report.append(renderSection("Foreign Keys",
+                new String[]{"Table", "Foreign Key", "Status"}, foreignKeyRows));
+        report.append("===================================================================");
+        log.info("\n{}", report);
+    }
+
+    private String[] buildTableRow(String table) {
+        if (blacklist.test(table)) {
+            return new String[]{table, "-", "-", "SKIPPED"};
+        }
+        NumericResult h2Rows = count(source, sourceSchema, table);
+        NumericResult postgresqlRows = count(target, targetSchema, table);
+        String status = !h2Rows.success() || !postgresqlRows.success()
+                ? "ERROR"
+                : difference(postgresqlRows.value().subtract(h2Rows.value()));
+        return new String[]{table, h2Rows.display(), postgresqlRows.display(), status};
+    }
+
+    private String[] buildSequenceRow(SequenceDefinition sequence) {
+        if (blacklist.test(sequence.name())) {
+            return new String[]{sequence.name(), "-", "-", "SKIPPED"};
+        }
+        NumericResult targetValue = targetSequenceValue(sequence.name());
+        String status = !targetValue.success()
+                ? "ERROR"
+                : difference(targetValue.value().subtract(sequence.baseValue()));
+        return new String[]{
+                sequence.name(),
+                number(sequence.baseValue()),
+                targetValue.display(),
+                status
+        };
+    }
+
+    private NumericResult count(JdbcTemplate jdbc, String schema, String table) {
+        try {
+            Long count = jdbc.queryForObject("SELECT COUNT(*) FROM " + qualified(schema, table), Long.class);
+            return count == null ? NumericResult.error("NO DATA") : NumericResult.success(BigDecimal.valueOf(count));
+        } catch (DataAccessException ex) {
+            return NumericResult.error(message(ex));
+        }
+    }
+
+    private NumericResult targetSequenceValue(String sequence) {
+        try {
+            BigDecimal value;
+            if (h2TestTarget) {
+                value = target.queryForObject(
+                        "SELECT BASE_VALUE FROM INFORMATION_SCHEMA.SEQUENCES " +
+                                "WHERE SEQUENCE_SCHEMA = ? AND SEQUENCE_NAME = ?",
+                        BigDecimal.class,
+                        targetSchema,
+                        sequence
+                );
+            } else {
+                value = target.queryForObject(
+                        "SELECT last_value FROM " + qualified(targetSchema, sequence),
+                        BigDecimal.class
+                );
+            }
+            return value == null ? NumericResult.error("NO DATA") : NumericResult.success(value);
+        } catch (DataAccessException ex) {
+            return NumericResult.error(message(ex));
+        }
+    }
+
+    private String constraintStatus(String table, String constraint) {
+        try {
+            Integer count = target.queryForObject(
+                    "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS " +
+                            "WHERE CONSTRAINT_SCHEMA = ? AND TABLE_NAME = ? AND CONSTRAINT_NAME = ?",
+                    Integer.class,
+                    targetSchema,
+                    table,
+                    constraint
+            );
+            return count != null && count > 0 ? "MIGRATED" : "MISSING";
+        } catch (DataAccessException ex) {
+            return "ERROR: " + message(ex);
+        }
+    }
+
+    private String objectStatus(String objectName, String objectType, String table) {
+        if (blacklist.test(objectName)) {
+            return "SKIPPED";
+        }
+        try (Connection connection = targetDataSource.getConnection()) {
+            DatabaseMetaData metadata = connection.getMetaData();
+            boolean found = switch (objectType) {
+                case "VIEW" -> hasTableType(metadata, connection, objectName, "VIEW");
+                case "INDEX" -> hasIndex(metadata, connection, table, objectName);
+                case "FOREIGN_KEY" -> hasForeignKey(metadata, connection, table, objectName);
+                default -> false;
+            };
+            return found ? "MIGRATED" : "MISSING";
+        } catch (SQLException ex) {
+            return "ERROR: " + message(ex);
+        }
+    }
+
+    private boolean hasTableType(DatabaseMetaData metadata, Connection connection, String object, String type)
+            throws SQLException {
+        try (ResultSet rs = metadata.getTables(connection.getCatalog(), targetSchema, object, new String[]{type})) {
+            while (rs.next()) {
+                if (object.equals(rs.getString("TABLE_NAME"))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private boolean hasIndex(DatabaseMetaData metadata, Connection connection, String table, String index)
+            throws SQLException {
+        try (ResultSet rs = metadata.getIndexInfo(connection.getCatalog(), targetSchema, table, false, false)) {
+            while (rs.next()) {
+                if (index.equals(rs.getString("INDEX_NAME"))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private boolean hasForeignKey(DatabaseMetaData metadata, Connection connection, String table, String key)
+            throws SQLException {
+        try (ResultSet rs = metadata.getImportedKeys(connection.getCatalog(), targetSchema, table)) {
+            while (rs.next()) {
+                if (key.equals(rs.getString("FK_NAME"))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private String renderSection(String title, String[] headers, List<String[]> inputRows) {
+        List<String[]> rows = inputRows.isEmpty() ? Collections.singletonList(emptyRow(headers.length)) : inputRows;
+        int[] widths = new int[headers.length];
+        for (int column = 0; column < headers.length; column++) {
+            widths[column] = headers[column].length();
+            for (String[] row : rows) {
+                widths[column] = Math.max(widths[column], row[column] == null ? 0 : row[column].length());
+            }
+        }
+
+        String horizontal = horizontal(widths);
+        StringBuilder out = new StringBuilder(title).append('\n').append(horizontal).append('\n')
+                .append(row(headers, widths)).append('\n').append(horizontal).append('\n');
+        rows.forEach(value -> out.append(row(value, widths)).append('\n'));
+        return out.append(horizontal).append('\n').toString();
+    }
+
+    private String[] emptyRow(int length) {
+        String[] row = new String[length];
+        row[0] = "(none)";
+        for (int i = 1; i < length; i++) row[i] = "-";
+        return row;
+    }
+
+    private String horizontal(int[] widths) {
+        StringBuilder out = new StringBuilder("+");
+        for (int width : widths) out.append("-".repeat(width + 2)).append('+');
+        return out.toString();
+    }
+
+    private String row(String[] values, int[] widths) {
+        StringBuilder out = new StringBuilder("|");
+        for (int i = 0; i < widths.length; i++) {
+            String value = values[i] == null ? "" : values[i];
+            out.append(' ').append(value).append(" ".repeat(widths[i] - value.length() + 1)).append('|');
+        }
+        return out.toString();
+    }
+
+    private String difference(BigDecimal difference) {
+        int compared = difference.compareTo(BigDecimal.ZERO);
+        if (compared == 0) return "MATCH";
+        String value = difference.stripTrailingZeros().toPlainString();
+        return compared > 0 ? "+" + value : value;
+    }
+
+    private String number(BigDecimal value) {
+        if (value == null) return "-";
+        if (value.compareTo(BigDecimal.ZERO) == 0) return "0";
+        return value.stripTrailingZeros().toPlainString();
+    }
+
+    private String qualified(String schema, String object) {
+        return quote(schema) + "." + quote(object);
+    }
+
+    private String quote(String identifier) {
+        return "\"" + identifier.replace("\"", "\"\"") + "\"";
+    }
+
+    private String message(Throwable throwable) {
+        String value = throwable.getMessage();
+        if ((value == null || value.isBlank()) && throwable.getCause() != null) {
+            return message(throwable.getCause());
+        }
+        if (value == null || value.isBlank()) return throwable.toString();
+        value = value.replaceAll("\\s+", " ").trim();
+        return value.length() <= 80 ? value : value.substring(0, 80);
+    }
+
+    private record NumericResult(BigDecimal value, String error) {
+        static NumericResult success(BigDecimal value) {
+            return new NumericResult(value, null);
+        }
+
+        static NumericResult error(String error) {
+            return new NumericResult(null, error);
+        }
+
+        boolean success() {
+            return error == null;
+        }
+
+        String display() {
+            if (!success()) return "ERR: " + error;
+            if (value.compareTo(BigDecimal.ZERO) == 0) return "0";
+            return value.stripTrailingZeros().toPlainString();
+        }
+    }
+}

--- a/src/main/java/com/example/h2sync/service/H2ToPostgresqlViewSqlTranslator.java
+++ b/src/main/java/com/example/h2sync/service/H2ToPostgresqlViewSqlTranslator.java
@@ -1,0 +1,331 @@
+package com.example.h2sync.service;
+
+import java.util.Locale;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Applies the small set of dialect changes normally needed by views produced by
+ * the Oracle-to-H2 loader before those views are created in PostgreSQL.
+ */
+final class H2ToPostgresqlViewSqlTranslator {
+
+    private final String sourceSchema;
+    private final String targetSchema;
+
+    H2ToPostgresqlViewSqlTranslator(String sourceSchema, String targetSchema) {
+        this.sourceSchema = sourceSchema;
+        this.targetSchema = targetSchema;
+    }
+
+    String translate(String sql) {
+        if (sql == null || sql.isBlank()) {
+            throw new IllegalArgumentException("H2 view definition is blank");
+        }
+
+        String translated = stripSqlTerminator(sql);
+        translated = replaceSchemaQualifier(translated);
+        translated = replaceTokenOutsideQuotes(translated, "NVL", "COALESCE", true);
+        translated = replaceTokenOutsideQuotes(translated, "IFNULL", "COALESCE", true);
+        translated = replaceTokenOutsideQuotes(translated, "SYSDATE", "CURRENT_TIMESTAMP", false);
+        translated = replaceTokenOutsideQuotes(translated, "SYSTIMESTAMP", "CURRENT_TIMESTAMP", false);
+        translated = replaceTokenOutsideQuotes(translated, "MINUS", "EXCEPT", false);
+        translated = translated.replaceAll("(?i)\\bCURRENT_TIMESTAMP\\s*\\(\\s*\\)", "CURRENT_TIMESTAMP")
+                .replaceAll("(?i)\\bCURRENT_DATE\\s*\\(\\s*\\)", "CURRENT_DATE")
+                .replaceAll("(?i)\\bCURRENT_TIME\\s*\\(\\s*\\)", "CURRENT_TIME");
+        translated = rewriteCanonicalH2Functions(translated);
+
+        // H2's Oracle mode exposes DUAL. PostgreSQL does not require it for
+        // simple scalar SELECT statements.
+        translated = translated.replaceAll(
+                "(?i)\\s+FROM\\s+(?:\\\"?" + Pattern.quote(targetSchema) + "\\\"?\\.)?\\\"?DUAL\\\"?(?=\\s*$)",
+                ""
+        );
+        return translated.trim();
+    }
+
+    private String rewriteCanonicalH2Functions(String sql) {
+        StringBuilder out = new StringBuilder(sql.length() + 32);
+        int i = 0;
+        while (i < sql.length()) {
+            char c = sql.charAt(i);
+            if (c == '\'' || c == '"') {
+                i = appendQuoted(sql, i, out);
+                continue;
+            }
+            if (!isIdentifierStart(c)) {
+                out.append(c);
+                i++;
+                continue;
+            }
+
+            int tokenStart = i++;
+            while (i < sql.length() && isIdentifierPart(sql.charAt(i))) i++;
+            String token = sql.substring(tokenStart, i);
+            String upper = token.toUpperCase(Locale.ROOT);
+            int open = skipWhitespace(sql, i);
+            if (open >= sql.length() || sql.charAt(open) != '(' || !isRewrittenFunction(upper)) {
+                out.append(token);
+                continue;
+            }
+
+            int close = findMatchingParenthesis(sql, open);
+            if (close < 0) {
+                out.append(token);
+                continue;
+            }
+            List<String> args = splitTopLevelArguments(sql.substring(open + 1, close)).stream()
+                    .map(String::trim)
+                    .map(this::rewriteCanonicalH2Functions)
+                    .toList();
+
+            if ("LISTAGG".equals(upper) && args.size() == 2) {
+                WithinGroup withinGroup = readWithinGroup(sql, close + 1);
+                if (withinGroup != null) {
+                    out.append("STRING_AGG(").append(args.get(0)).append(", ").append(args.get(1))
+                            .append(" ORDER BY ")
+                            .append(rewriteCanonicalH2Functions(withinGroup.orderBy()))
+                            .append(')');
+                    i = withinGroup.endIndex();
+                    continue;
+                }
+            }
+
+            String replacement = rewriteFunction(upper, args);
+            if (replacement == null) {
+                out.append(token).append(sql, i, close + 1);
+            } else {
+                out.append(replacement);
+            }
+            i = close + 1;
+        }
+        return out.toString();
+    }
+
+    private String rewriteFunction(String function, List<String> args) {
+        if ("DATE_TRUNC".equals(function) && args.size() == 2) {
+            String unit = args.get(0);
+            if (unit.matches("(?i)[A-Z_]+")) {
+                unit = "'" + unit.toLowerCase(Locale.ROOT) + "'";
+            }
+            return "DATE_TRUNC(" + unit + ", " + args.get(1) + ")";
+        }
+        if ("ADD_MONTHS".equals(function) && args.size() == 2) {
+            return "(" + args.get(0) + " + (" + args.get(1) + ") * INTERVAL '1 month')";
+        }
+        if ("LAST_DAY".equals(function) && args.size() == 1) {
+            return "(DATE_TRUNC('month', " + args.get(0) +
+                    ") + INTERVAL '1 month - 1 day')::date";
+        }
+        if ("RAWTOHEX".equals(function) && args.size() == 1) {
+            return "ENCODE(" + args.get(0) + ", 'hex')";
+        }
+        if ("HEXTORAW".equals(function) && args.size() == 1) {
+            return "DECODE(" + args.get(0) + ", 'hex')";
+        }
+        if ("LENGTHB".equals(function) && args.size() == 1) {
+            return "OCTET_LENGTH(" + args.get(0) + ")";
+        }
+        return null;
+    }
+
+    private boolean isRewrittenFunction(String token) {
+        return token.equals("DATE_TRUNC") || token.equals("ADD_MONTHS") || token.equals("LAST_DAY")
+                || token.equals("LISTAGG") || token.equals("RAWTOHEX") || token.equals("HEXTORAW")
+                || token.equals("LENGTHB");
+    }
+
+    private WithinGroup readWithinGroup(String sql, int start) {
+        int i = skipWhitespace(sql, start);
+        if (!regionMatchesToken(sql, i, "WITHIN")) return null;
+        i = skipWhitespace(sql, i + "WITHIN".length());
+        if (!regionMatchesToken(sql, i, "GROUP")) return null;
+        i = skipWhitespace(sql, i + "GROUP".length());
+        if (i >= sql.length() || sql.charAt(i) != '(') return null;
+        int close = findMatchingParenthesis(sql, i);
+        if (close < 0) return null;
+        String content = sql.substring(i + 1, close).trim();
+        if (!content.regionMatches(true, 0, "ORDER", 0, "ORDER".length())) return null;
+        int by = skipWhitespace(content, "ORDER".length());
+        if (!content.regionMatches(true, by, "BY", 0, 2)) return null;
+        return new WithinGroup(content.substring(by + 2).trim(), close + 1);
+    }
+
+    private boolean regionMatchesToken(String sql, int offset, String token) {
+        if (offset < 0 || offset + token.length() > sql.length()
+                || !sql.regionMatches(true, offset, token, 0, token.length())) {
+            return false;
+        }
+        int end = offset + token.length();
+        return (offset == 0 || !isIdentifierPart(sql.charAt(offset - 1)))
+                && (end == sql.length() || !isIdentifierPart(sql.charAt(end)));
+    }
+
+    private int appendQuoted(String sql, int start, StringBuilder out) {
+        char quote = sql.charAt(start);
+        int i = start;
+        out.append(quote);
+        i++;
+        while (i < sql.length()) {
+            char current = sql.charAt(i);
+            out.append(current);
+            if (current == quote) {
+                if (i + 1 < sql.length() && sql.charAt(i + 1) == quote) {
+                    out.append(sql.charAt(i + 1));
+                    i += 2;
+                    continue;
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        return i;
+    }
+
+    private int skipWhitespace(String sql, int index) {
+        int i = index;
+        while (i < sql.length() && Character.isWhitespace(sql.charAt(i))) i++;
+        return i;
+    }
+
+    private int findMatchingParenthesis(String sql, int open) {
+        int depth = 0;
+        boolean singleQuoted = false;
+        boolean doubleQuoted = false;
+        for (int i = open; i < sql.length(); i++) {
+            char c = sql.charAt(i);
+            if (c == '\'' && !doubleQuoted) {
+                if (singleQuoted && i + 1 < sql.length() && sql.charAt(i + 1) == '\'') i++;
+                else singleQuoted = !singleQuoted;
+                continue;
+            }
+            if (c == '"' && !singleQuoted) {
+                if (doubleQuoted && i + 1 < sql.length() && sql.charAt(i + 1) == '"') i++;
+                else doubleQuoted = !doubleQuoted;
+                continue;
+            }
+            if (singleQuoted || doubleQuoted) continue;
+            if (c == '(') depth++;
+            else if (c == ')' && --depth == 0) return i;
+        }
+        return -1;
+    }
+
+    private List<String> splitTopLevelArguments(String input) {
+        List<String> args = new ArrayList<>();
+        int start = 0;
+        int depth = 0;
+        boolean singleQuoted = false;
+        boolean doubleQuoted = false;
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == '\'' && !doubleQuoted) {
+                if (singleQuoted && i + 1 < input.length() && input.charAt(i + 1) == '\'') i++;
+                else singleQuoted = !singleQuoted;
+                continue;
+            }
+            if (c == '"' && !singleQuoted) {
+                if (doubleQuoted && i + 1 < input.length() && input.charAt(i + 1) == '"') i++;
+                else doubleQuoted = !doubleQuoted;
+                continue;
+            }
+            if (singleQuoted || doubleQuoted) continue;
+            if (c == '(') depth++;
+            else if (c == ')') depth--;
+            else if (c == ',' && depth == 0) {
+                args.add(input.substring(start, i));
+                start = i + 1;
+            }
+        }
+        args.add(input.substring(start));
+        return args;
+    }
+
+    private String stripSqlTerminator(String sql) {
+        String out = sql.trim();
+        while (out.endsWith(";") || out.endsWith("/")) {
+            out = out.substring(0, out.length() - 1).trim();
+        }
+        return out;
+    }
+
+    private String replaceSchemaQualifier(String sql) {
+        if (sourceSchema == null || sourceSchema.isBlank()) {
+            return sql;
+        }
+        String quotedSource = Pattern.quote("\"" + sourceSchema + "\"");
+        String quotedTarget = "\"" + targetSchema.replace("\"", "\"\"") + "\"";
+        String result = sql.replaceAll(
+                "(?i)" + quotedSource + "\\s*\\.",
+                Matcher.quoteReplacement(quotedTarget + ".")
+        );
+        return result.replaceAll(
+                "(?i)(?<![A-Z0-9_$#\"])(" + Pattern.quote(sourceSchema) + ")\\s*\\.",
+                Matcher.quoteReplacement(quotedTarget + ".")
+        );
+    }
+
+    private String replaceTokenOutsideQuotes(String sql, String source, String replacement, boolean functionOnly) {
+        StringBuilder out = new StringBuilder(sql.length() + 16);
+        int i = 0;
+        while (i < sql.length()) {
+            char c = sql.charAt(i);
+            if (c == '\'' || c == '"') {
+                char quote = c;
+                out.append(c);
+                i++;
+                while (i < sql.length()) {
+                    char current = sql.charAt(i);
+                    out.append(current);
+                    if (current == quote) {
+                        if (i + 1 < sql.length() && sql.charAt(i + 1) == quote) {
+                            out.append(sql.charAt(i + 1));
+                            i += 2;
+                            continue;
+                        }
+                        i++;
+                        break;
+                    }
+                    i++;
+                }
+                continue;
+            }
+
+            if (isIdentifierStart(c)) {
+                int start = i++;
+                while (i < sql.length() && isIdentifierPart(sql.charAt(i))) {
+                    i++;
+                }
+                String token = sql.substring(start, i);
+                int next = i;
+                while (next < sql.length() && Character.isWhitespace(sql.charAt(next))) {
+                    next++;
+                }
+                if (token.toUpperCase(Locale.ROOT).equals(source)
+                        && (!functionOnly || (next < sql.length() && sql.charAt(next) == '('))) {
+                    out.append(replacement);
+                } else {
+                    out.append(token);
+                }
+                continue;
+            }
+
+            out.append(c);
+            i++;
+        }
+        return out.toString();
+    }
+
+    private boolean isIdentifierStart(char c) {
+        return Character.isLetter(c) || c == '_' || c == '$' || c == '#';
+    }
+
+    private boolean isIdentifierPart(char c) {
+        return Character.isLetterOrDigit(c) || c == '_' || c == '$' || c == '#';
+    }
+
+    private record WithinGroup(String orderBy, int endIndex) {
+    }
+}

--- a/src/main/java/com/example/h2sync/service/OracleLoaderService.java
+++ b/src/main/java/com/example/h2sync/service/OracleLoaderService.java
@@ -2,12 +2,14 @@ package com.example.h2sync.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 import javax.sql.DataSource;
 
 @Service
+@ConditionalOnProperty(prefix = "loader", name = "enabled", havingValue = "true")
 public class OracleLoaderService extends AbstractOracleLoaderService {
 
     @Autowired

--- a/src/main/java/com/example/h2sync/service/OracleSampleLoaderService.java
+++ b/src/main/java/com/example/h2sync/service/OracleSampleLoaderService.java
@@ -2,6 +2,7 @@ package com.example.h2sync.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.stereotype.Service;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 import javax.sql.DataSource;
 
 @Service
+@ConditionalOnProperty(prefix = "sample.loader", name = "enabled", havingValue = "true")
 public class OracleSampleLoaderService extends AbstractOracleLoaderService {
 
     private final int rowLimit;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,30 @@ oracle:
   password: YOUR_ORACLE_PASSWORD
   schema: YOUR_ORACLE_SCHEMA
 
+postgresql:
+  url: jdbc:postgresql://YOUR_POSTGRESQL_HOST:5432/YOUR_DATABASE?reWriteBatchedInserts=true
+  username: YOUR_POSTGRESQL_USER
+  password: YOUR_POSTGRESQL_PASSWORD
+  driver-class: org.postgresql.Driver
+  schema: public
+  loader:
+    # Enable only after the PostgreSQL connection above has been configured.
+    enabled: false
+    startup: true
+    cron: "0 30 3 * * *"
+    zone: Asia/Shanghai
+    source-schema: PUBLIC
+    # H2 is a single-file embedded database. Keep full-table reads serial by default.
+    source-read-threads: 1
+    # PostgreSQL-only constraint and index creation can still run in parallel.
+    target-threads: 4
+    batchSize: 1000
+    maxRetries: 3
+    blacklist: []
+
 loader:
-  enabled: true
+  # Oracle -> H2 was a one-time migration and is retained only as legacy code.
+  enabled: false
   cron: "0 30 2 * * *"
   threads: 4
   batchSize: 1000
@@ -31,6 +53,7 @@ backup:
 
 sample:
   loader:
+    enabled: false
     h2-url: jdbc:h2:./data-sample/h2db;MODE=Oracle;DATABASE_TO_UPPER=false;AUTO_SERVER=TRUE
     h2-username: sa
     h2-password: ""

--- a/src/test/java/com/example/h2sync/service/H2ToPostgresqlLoaderServiceTest.java
+++ b/src/test/java/com/example/h2sync/service/H2ToPostgresqlLoaderServiceTest.java
@@ -1,0 +1,271 @@
+package com.example.h2sync.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class H2ToPostgresqlLoaderServiceTest {
+
+    @Test
+    void fullRefreshCopiesDataConstraintsIndexesForeignKeysViewsAndSequences() throws Exception {
+        DriverManagerDataSource sourceDataSource = dataSource("source", "Oracle");
+        DriverManagerDataSource targetDataSource = dataSource("target", "PostgreSQL");
+        JdbcTemplate source = new JdbcTemplate(sourceDataSource);
+        JdbcTemplate target = new JdbcTemplate(targetDataSource);
+        setupSource(source);
+
+        H2ToPostgresqlLoaderService loader = new H2ToPostgresqlLoaderService(
+                source,
+                sourceDataSource,
+                targetDataSource,
+                "PUBLIC",
+                "TARGET",
+                1,
+                3,
+                2,
+                2,
+                ""
+        );
+
+        loader.runFullRefresh();
+
+        assertEquals(2, target.queryForObject(
+                "SELECT COUNT(*) FROM \"TARGET\".\"DEPARTMENT\"", Integer.class));
+        assertEquals(3, target.queryForObject(
+                "SELECT COUNT(*) FROM \"TARGET\".\"EMPLOYEE\"", Integer.class));
+        assertEquals("Alice", target.queryForObject(
+                "SELECT \"NAME\" FROM \"TARGET\".\"EMPLOYEE\" WHERE \"ID\" = 1", String.class));
+        assertArrayEquals(new byte[]{1, 2}, target.queryForObject(
+                "SELECT \"PHOTO\" FROM \"TARGET\".\"EMPLOYEE\" WHERE \"ID\" = 1", byte[].class));
+        assertEquals("first", target.queryForObject(
+                "SELECT \"NOTES\" FROM \"TARGET\".\"EMPLOYEE\" WHERE \"ID\" = 1", String.class));
+        assertEquals("Engineering", target.queryForObject(
+                "SELECT \"DEPARTMENT_CODE\" FROM \"TARGET\".\"EMPLOYEE_VIEW\" WHERE \"ID\" = 2", String.class));
+        target.update("INSERT INTO \"TARGET\".\"AUDIT_EVENT\" (\"MESSAGE\") VALUES (?)", "third");
+        assertEquals(14L, target.queryForObject(
+                "SELECT MAX(\"ID\") FROM \"TARGET\".\"AUDIT_EVENT\"", Long.class));
+        assertEquals("THIRD", target.queryForObject(
+                "SELECT \"MESSAGE_UPPER\" FROM \"TARGET\".\"AUDIT_EVENT\" WHERE \"ID\" = 14",
+                String.class));
+
+        Set<String> constraints = new HashSet<>(target.queryForList(
+                "SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS " +
+                        "WHERE TABLE_SCHEMA = 'TARGET' AND TABLE_NAME = 'EMPLOYEE'",
+                String.class
+        ));
+        assertTrue(constraints.contains("PK_EMPLOYEE"));
+        assertTrue(constraints.contains("UQ_EMPLOYEE_EMAIL"));
+        assertTrue(constraints.contains("FK_EMPLOYEE_DEPARTMENT"));
+
+        Set<String> indexes = indexNames(targetDataSource, "TARGET", "EMPLOYEE");
+        assertTrue(indexes.contains("IDX_EMPLOYEE_NAME"));
+        assertTrue(indexes.contains("UX_EMPLOYEE_NAME_DEPT"));
+
+        assertEquals(new BigDecimal("100"), target.queryForObject(
+                "SELECT BASE_VALUE FROM INFORMATION_SCHEMA.SEQUENCES " +
+                        "WHERE SEQUENCE_SCHEMA = 'TARGET' AND SEQUENCE_NAME = 'EMPLOYEE_SEQ'",
+                BigDecimal.class
+        ));
+
+        assertEquals(0, target.queryForObject(
+                "SELECT COUNT(*) FROM \"TARGET\".\"H2_PG_ETL_FAIL_LOG\" WHERE \"ATTEMPT_COUNT\" > 0",
+                Integer.class
+        ));
+        assertTrue(target.queryForObject(
+                "SELECT COUNT(*) FROM \"TARGET\".\"H2_PG_ETL_FAIL_LOG\"", Integer.class) >= 7);
+    }
+
+    @Test
+    void fullRefreshHonorsCaseInsensitiveBlacklist() {
+        DriverManagerDataSource sourceDataSource = dataSource("blacklist-source", "Oracle");
+        DriverManagerDataSource targetDataSource = dataSource("blacklist-target", "PostgreSQL");
+        JdbcTemplate source = new JdbcTemplate(sourceDataSource);
+        setupSource(source);
+
+        H2ToPostgresqlLoaderService loader = new H2ToPostgresqlLoaderService(
+                source,
+                sourceDataSource,
+                targetDataSource,
+                "PUBLIC",
+                "TARGET",
+                1,
+                2,
+                10,
+                1,
+                "public.employee, employee_seq, employee_view, employee_view_2"
+        );
+        loader.runFullRefresh();
+
+        JdbcTemplate target = new JdbcTemplate(targetDataSource);
+        assertEquals(0, target.queryForObject(
+                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES " +
+                        "WHERE TABLE_SCHEMA = 'TARGET' AND TABLE_NAME = 'EMPLOYEE'",
+                Integer.class
+        ));
+        assertEquals(0, target.queryForObject(
+                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.SEQUENCES " +
+                        "WHERE SEQUENCE_SCHEMA = 'TARGET' AND SEQUENCE_NAME = 'EMPLOYEE_SEQ'",
+                Integer.class
+        ));
+        assertEquals(2, target.queryForObject(
+                "SELECT COUNT(*) FROM \"TARGET\".\"DEPARTMENT\"", Integer.class));
+    }
+
+    @Test
+    void terminalObjectFailureMakesTheWholeMigrationFail() {
+        DriverManagerDataSource sourceDataSource = dataSource("failure-source", "Oracle");
+        DriverManagerDataSource targetDataSource = dataSource("failure-target", "PostgreSQL");
+        JdbcTemplate source = new JdbcTemplate(sourceDataSource);
+        setupSource(source);
+
+        H2ToPostgresqlLoaderService loader = new H2ToPostgresqlLoaderService(
+                source,
+                sourceDataSource,
+                targetDataSource,
+                "PUBLIC",
+                "TARGET",
+                1,
+                2,
+                10,
+                1,
+                "employee"
+        );
+
+        H2ToPostgresqlLoaderService.MigrationIncompleteException error = assertThrows(
+                H2ToPostgresqlLoaderService.MigrationIncompleteException.class,
+                loader::runFullRefresh
+        );
+
+        assertTrue(error.getFailureCount() >= 1);
+        JdbcTemplate target = new JdbcTemplate(targetDataSource);
+        assertTrue(target.queryForObject(
+                "SELECT COUNT(*) FROM \"TARGET\".\"H2_PG_ETL_FAIL_LOG\" WHERE \"ATTEMPT_COUNT\" > 0",
+                Integer.class
+        ) >= 1);
+    }
+
+    @Test
+    void viewTranslatorChangesOnlyDialectTokensOutsideQuotedContent() {
+        H2ToPostgresqlViewSqlTranslator translator =
+                new H2ToPostgresqlViewSqlTranslator("PUBLIC", "reporting");
+
+        String translated = translator.translate(
+                "SELECT NVL(\"NAME\", 'NVL(SYSDATE)'), SYSDATE FROM \"PUBLIC\".\"EMPLOYEE\";"
+        );
+
+        assertEquals(
+                "SELECT COALESCE(\"NAME\", 'NVL(SYSDATE)'), CURRENT_TIMESTAMP " +
+                        "FROM \"reporting\".\"EMPLOYEE\"",
+                translated
+        );
+    }
+
+    @Test
+    void viewTranslatorRewritesCanonicalH2DateAndAggregateFunctions() {
+        H2ToPostgresqlViewSqlTranslator translator =
+                new H2ToPostgresqlViewSqlTranslator("PUBLIC", "reporting");
+
+        String translated = translator.translate(
+                "SELECT DATE_TRUNC(DAY, \"D\"), ADD_MONTHS(\"D\", 2), LAST_DAY(\"D\"), " +
+                        "LISTAGG(\"NAME\", ',') WITHIN GROUP (ORDER BY \"ID\") " +
+                        "FROM \"PUBLIC\".\"EMP\""
+        );
+
+        assertEquals(
+                "SELECT DATE_TRUNC('day', \"D\"), (\"D\" + (2) * INTERVAL '1 month'), " +
+                        "(DATE_TRUNC('month', \"D\") + INTERVAL '1 month - 1 day')::date, " +
+                        "STRING_AGG(\"NAME\", ',' ORDER BY \"ID\") FROM \"reporting\".\"EMP\"",
+                translated
+        );
+    }
+
+    private static void setupSource(JdbcTemplate jdbc) {
+        jdbc.execute("CREATE TABLE \"DEPARTMENT\" (" +
+                "\"ID\" INTEGER NOT NULL, " +
+                "\"CODE\" VARCHAR(32) NOT NULL, " +
+                "CONSTRAINT \"PK_DEPARTMENT\" PRIMARY KEY (\"ID\"), " +
+                "CONSTRAINT \"UQ_DEPARTMENT_CODE\" UNIQUE (\"CODE\"))");
+        jdbc.execute("CREATE TABLE \"EMPLOYEE\" (" +
+                "\"ID\" BIGINT NOT NULL, " +
+                "\"DEPARTMENT_ID\" INTEGER NOT NULL, " +
+                "\"NAME\" VARCHAR(64) NOT NULL, " +
+                "\"EMAIL\" VARCHAR(128), " +
+                "\"SALARY\" DECIMAL(12,2), " +
+                "\"PHOTO\" BLOB, " +
+                "\"NOTES\" CLOB, " +
+                "CONSTRAINT \"PK_EMPLOYEE\" PRIMARY KEY (\"ID\"), " +
+                "CONSTRAINT \"UQ_EMPLOYEE_EMAIL\" UNIQUE (\"EMAIL\"), " +
+                "CONSTRAINT \"FK_EMPLOYEE_DEPARTMENT\" FOREIGN KEY (\"DEPARTMENT_ID\") " +
+                "REFERENCES \"DEPARTMENT\" (\"ID\"))");
+        jdbc.execute("CREATE TABLE \"AUDIT_EVENT\" (" +
+                "\"ID\" BIGINT GENERATED BY DEFAULT AS IDENTITY (START WITH 10 INCREMENT BY 2), " +
+                "\"MESSAGE\" VARCHAR(128) NOT NULL, " +
+                "\"MESSAGE_UPPER\" VARCHAR(128) GENERATED ALWAYS AS (UPPER(\"MESSAGE\")), " +
+                "CONSTRAINT \"PK_AUDIT_EVENT\" PRIMARY KEY (\"ID\"))");
+        jdbc.execute("CREATE INDEX \"IDX_EMPLOYEE_NAME\" ON \"EMPLOYEE\" (\"NAME\")");
+        jdbc.execute("CREATE UNIQUE INDEX \"UX_EMPLOYEE_NAME_DEPT\" " +
+                "ON \"EMPLOYEE\" (\"NAME\", \"DEPARTMENT_ID\")");
+        jdbc.execute("CREATE SEQUENCE \"EMPLOYEE_SEQ\" START WITH 100 INCREMENT BY 5");
+
+        jdbc.update("INSERT INTO \"DEPARTMENT\" (\"ID\", \"CODE\") VALUES (?, ?)", 10, "Sales");
+        jdbc.update("INSERT INTO \"DEPARTMENT\" (\"ID\", \"CODE\") VALUES (?, ?)", 20, "Engineering");
+        jdbc.update("INSERT INTO \"EMPLOYEE\" VALUES (?, ?, ?, ?, ?, ?, ?)",
+                1L, 10, "Alice", "alice@example.com", new BigDecimal("100.10"),
+                new byte[]{1, 2}, "first");
+        jdbc.update("INSERT INTO \"EMPLOYEE\" VALUES (?, ?, ?, ?, ?, ?, ?)",
+                2L, 20, "Bob", "bob@example.com", new BigDecimal("200.20"),
+                new byte[]{3, 4}, "second");
+        jdbc.update("INSERT INTO \"EMPLOYEE\" VALUES (?, ?, ?, ?, ?, ?, ?)",
+                3L, 20, "Carol", null, new BigDecimal("300.30"), null, null);
+        jdbc.update("INSERT INTO \"AUDIT_EVENT\" (\"MESSAGE\") VALUES (?)", "first");
+        jdbc.update("INSERT INTO \"AUDIT_EVENT\" (\"MESSAGE\") VALUES (?)", "second");
+
+        jdbc.execute("CREATE VIEW \"EMPLOYEE_VIEW\" (\"ID\", \"NAME\", \"DEPARTMENT_CODE\") AS " +
+                "SELECT E.\"ID\", E.\"NAME\", D.\"CODE\" " +
+                "FROM \"EMPLOYEE\" E JOIN \"DEPARTMENT\" D ON E.\"DEPARTMENT_ID\" = D.\"ID\"");
+        jdbc.execute("CREATE VIEW \"EMPLOYEE_VIEW_2\" AS " +
+                "SELECT \"ID\", \"NAME\" FROM \"EMPLOYEE_VIEW\"");
+    }
+
+    private static DriverManagerDataSource dataSource(String prefix, String mode) {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:" + prefix + randomSuffix() +
+                ";MODE=" + mode + ";DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+
+    private static String randomSuffix() {
+        return UUID.randomUUID().toString().replace("-", "").toLowerCase(Locale.ROOT);
+    }
+
+    private static Set<String> indexNames(DriverManagerDataSource dataSource, String schema, String table)
+            throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             ResultSet rs = connection.getMetaData().getIndexInfo(connection.getCatalog(), schema, table, false, false)) {
+            Set<String> result = new HashSet<>();
+            while (rs.next()) {
+                String name = rs.getString("INDEX_NAME");
+                if (name != null) result.add(name);
+            }
+            return result;
+        }
+    }
+
+}

--- a/src/test/java/com/example/h2sync/service/OracleLoaderServiceTest.java
+++ b/src/test/java/com/example/h2sync/service/OracleLoaderServiceTest.java
@@ -61,13 +61,13 @@ class OracleLoaderServiceTest {
 
         assertEquals(3, target.queryForObject("SELECT COUNT(*) FROM \"EMP\"", Integer.class));
         assertEquals(2, target.queryForObject("SELECT COUNT(*) FROM \"DEPT\"", Integer.class));
-        assertEquals(3, target.queryForObject("SELECT COUNT(*) FROM \"VW_EMP_VIEW\"", Integer.class));
+        assertEquals(3, target.queryForObject("SELECT COUNT(*) FROM \"EMP_VIEW\"", Integer.class));
 
         assertEquals(0, trackingOracle.getOpenConnections(), "Oracle connections must be closed after refresh");
         assertTrue(trackingOracle.getMaxOpenConnections() >= 2,
                 "Expected at least two concurrent Oracle connections during parallel load");
-        assertEquals(7, trackingOracle.getTotalConnections(),
-                "Unexpected number of Oracle connections opened during refresh");
+        assertTrue(trackingOracle.getTotalConnections() >= 7,
+                "Expected metadata, streaming and validation connections to be independent");
     }
 
     @Test
@@ -82,7 +82,8 @@ class OracleLoaderServiceTest {
                 ""
         );
 
-        Method method = OracleLoaderService.class.getDeclaredMethod("mapType", int.class, int.class, int.class, int.class);
+        Method method = AbstractOracleLoaderService.class.getDeclaredMethod(
+                "mapType", int.class, int.class, int.class, int.class);
         method.setAccessible(true);
 
         String decimalType = (String) method.invoke(loader, Types.NUMERIC, 0, -127, 0);
@@ -233,7 +234,7 @@ class OracleLoaderServiceTest {
     private static DriverManagerDataSource newH2DataSource(String dbName) {
         DriverManagerDataSource ds = new DriverManagerDataSource();
         ds.setDriverClassName("org.h2.Driver");
-        ds.setUrl("jdbc:h2:mem:" + dbName + ";MODE=Oracle;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1");
+        ds.setUrl("jdbc:h2:mem:" + dbName + ";MODE=Oracle;DATABASE_TO_UPPER=true;DB_CLOSE_DELAY=-1");
         ds.setUsername("sa");
         ds.setPassword("");
         return ds;
@@ -247,10 +248,19 @@ class OracleLoaderServiceTest {
         jdbc.execute("DROP TABLE IF EXISTS ALL_TABLES");
         jdbc.execute("DROP TABLE IF EXISTS ALL_VIEWS");
         jdbc.execute("DROP TABLE IF EXISTS ALL_SEQUENCES");
+        jdbc.execute("DROP TABLE IF EXISTS ALL_TAB_COLUMNS");
+        jdbc.execute("DROP TABLE IF EXISTS ALL_CONSTRAINTS");
+        jdbc.execute("DROP TABLE IF EXISTS ALL_CONS_COLUMNS");
         jdbc.execute("CREATE TABLE ALL_TABLES (OWNER VARCHAR(128), TABLE_NAME VARCHAR(128))");
-        jdbc.execute("CREATE TABLE ALL_VIEWS (OWNER VARCHAR(128), VIEW_NAME VARCHAR(128))");
+        jdbc.execute("CREATE TABLE ALL_VIEWS (OWNER VARCHAR(128), VIEW_NAME VARCHAR(128), TEXT CLOB)");
         jdbc.execute("CREATE TABLE ALL_SEQUENCES (SEQUENCE_OWNER VARCHAR(128), SEQUENCE_NAME VARCHAR(128), " +
                 "INCREMENT_BY BIGINT, LAST_NUMBER DECIMAL(38,0))");
+        jdbc.execute("CREATE TABLE ALL_TAB_COLUMNS (OWNER VARCHAR(128), TABLE_NAME VARCHAR(128), " +
+                "COLUMN_NAME VARCHAR(128), NULLABLE VARCHAR(1), COLUMN_ID INT)");
+        jdbc.execute("CREATE TABLE ALL_CONSTRAINTS (OWNER VARCHAR(128), CONSTRAINT_NAME VARCHAR(128), " +
+                "TABLE_NAME VARCHAR(128), CONSTRAINT_TYPE VARCHAR(1))");
+        jdbc.execute("CREATE TABLE ALL_CONS_COLUMNS (OWNER VARCHAR(128), CONSTRAINT_NAME VARCHAR(128), " +
+                "TABLE_NAME VARCHAR(128), COLUMN_NAME VARCHAR(128), POSITION INT)");
 
         jdbc.execute("CREATE SCHEMA IF NOT EXISTS " + schema);
         jdbc.execute("DROP TABLE IF EXISTS " + schema + ".EMP");
@@ -269,7 +279,47 @@ class OracleLoaderServiceTest {
 
         jdbc.update("INSERT INTO ALL_TABLES (OWNER, TABLE_NAME) VALUES (?, ?)", schema, "EMP");
         jdbc.update("INSERT INTO ALL_TABLES (OWNER, TABLE_NAME) VALUES (?, ?)", schema, "DEPT");
-        jdbc.update("INSERT INTO ALL_VIEWS (OWNER, VIEW_NAME) VALUES (?, ?)", schema, "EMP_VIEW");
+        jdbc.update("INSERT INTO ALL_VIEWS (OWNER, VIEW_NAME, TEXT) VALUES (?, ?, ?)",
+                schema, "EMP_VIEW", "SELECT ID, NAME FROM " + schema + ".EMP");
+
+        insertColumn(jdbc, schema, "EMP", "ID", "N", 1);
+        insertColumn(jdbc, schema, "EMP", "NAME", "Y", 2);
+        insertColumn(jdbc, schema, "EMP", "SALARY", "Y", 3);
+        insertColumn(jdbc, schema, "DEPT", "ID", "N", 1);
+        insertColumn(jdbc, schema, "DEPT", "TITLE", "Y", 2);
+        insertColumn(jdbc, schema, "EMP_VIEW", "ID", "N", 1);
+        insertColumn(jdbc, schema, "EMP_VIEW", "NAME", "Y", 2);
+
+        insertPrimaryKey(jdbc, schema, "EMP", "PK_EMP", "ID");
+        insertPrimaryKey(jdbc, schema, "DEPT", "PK_DEPT", "ID");
+    }
+
+    private static void insertColumn(
+            JdbcTemplate jdbc,
+            String schema,
+            String table,
+            String column,
+            String nullable,
+            int position
+    ) {
+        jdbc.update("INSERT INTO ALL_TAB_COLUMNS " +
+                        "(OWNER, TABLE_NAME, COLUMN_NAME, NULLABLE, COLUMN_ID) VALUES (?, ?, ?, ?, ?)",
+                schema, table, column, nullable, position);
+    }
+
+    private static void insertPrimaryKey(
+            JdbcTemplate jdbc,
+            String schema,
+            String table,
+            String constraint,
+            String column
+    ) {
+        jdbc.update("INSERT INTO ALL_CONSTRAINTS " +
+                        "(OWNER, CONSTRAINT_NAME, TABLE_NAME, CONSTRAINT_TYPE) VALUES (?, ?, ?, 'P')",
+                schema, constraint, table);
+        jdbc.update("INSERT INTO ALL_CONS_COLUMNS " +
+                        "(OWNER, CONSTRAINT_NAME, TABLE_NAME, COLUMN_NAME, POSITION) VALUES (?, ?, ?, ?, 1)",
+                schema, constraint, table, column);
     }
 
     static final class TrackingDataSource implements DataSource {


### PR DESCRIPTION
## Summary

- add a complete H2-to-PostgreSQL full-refresh pipeline for tables, data, sequences, primary/unique constraints, indexes, foreign keys, and dependency-aware views
- add PostgreSQL scheduling and manual API support, object retries, failure logging, and a final validation report
- protect the H2 source with serial reads by default, streamed BLOB/CLOB transfer, deferred PostgreSQL constraints/indexes, and rewritten JDBC batches
- disable the one-time Oracle-to-H2 loaders by default and create their beans only when explicitly enabled
- document configuration and operational behavior

## Why

The Oracle-to-H2 import was a one-time operation. The active requirement is to publish the existing H2 database to PostgreSQL without overloading H2, while preserving the same migration and validation guarantees.

## Impact

Configure `postgresql.*`, then set `postgresql.loader.enabled=true`. Manual refresh is available at `POST /api/postgresql-loader/full-refresh`. Terminal object failures are recorded in `H2_PG_ETL_FAIL_LOG`, included in the report, and make the overall run fail.

## Validation

- IntelliJ IDEA bundled Maven 3.9.11: `clean test`
- 13 tests passed
- `mvn -DskipTests package`
- `git diff --check`